### PR TITLE
Phase 1: Implement lexer with full Sage token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,3 @@ issues/
 
 # Environment
 .env
-
-
-# Added by cargo
-
-/target

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -100,7 +100,7 @@
   - Tokenize simple expressions
   - Tokenize function definitions
   - Tokenize string interpolation
-  - Edge cases: nested comments, unicode identifiers
+  - Edge cases: nested comments, underscore identifiers (ASCII only)
   - Error cases: unterminated strings, invalid characters
 
 ---

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,1 +1,704 @@
-// Tokenizer - turns source code into a stream of tokens
+pub mod token;
+
+use std::collections::VecDeque;
+use std::iter::Peekable;
+use std::str::CharIndices;
+use token::{Span, Token, TokenKind};
+
+#[derive(Debug, Clone)]
+pub struct LexerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for LexerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Error: {} at line {}, column {}",
+            self.message, self.line, self.column
+        )
+    }
+}
+
+pub struct Lexer<'a> {
+    source: &'a str,
+    chars: Peekable<CharIndices<'a>>,
+    line: usize,
+    column: usize,
+    errors: Vec<LexerError>,
+    pending_tokens: VecDeque<Token>,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Lexer {
+            source,
+            chars: source.char_indices().peekable(),
+            line: 1,
+            column: 1,
+            errors: Vec::new(),
+            pending_tokens: VecDeque::new(),
+        }
+    }
+
+    pub fn tokenize(&mut self) -> Vec<Token> {
+        let mut tokens = Vec::new();
+
+        while let Some(token) = self.next_token() {
+            tokens.push(token);
+        }
+
+        tokens.push(Token {
+            kind: TokenKind::EOF,
+            span: Span {
+                start: self.source.len(),
+                end: self.source.len(),
+                line: self.line,
+                column: self.column,
+            },
+        });
+
+        tokens
+    }
+
+    pub fn errors(&self) -> &[LexerError] {
+        &self.errors
+    }
+
+    fn next_token(&mut self) -> Option<Token> {
+        // Return any pending tokens from string interpolation first
+        if let Some(token) = self.pending_tokens.pop_front() {
+            return Some(token);
+        }
+
+        self.skip_whitespace();
+
+        let (start, ch) = *self.chars.peek()?;
+        let line = self.line;
+        let column = self.column;
+
+        match ch {
+            '\n' => {
+                self.advance();
+                Some(self.make_token(TokenKind::Newline, start, start + 1, line, column))
+            }
+
+            '(' => self.single_char_token(TokenKind::LParen, start, line, column),
+            ')' => self.single_char_token(TokenKind::RParen, start, line, column),
+            '{' => self.single_char_token(TokenKind::LBrace, start, line, column),
+            '}' => self.single_char_token(TokenKind::RBrace, start, line, column),
+            '[' => self.single_char_token(TokenKind::LBracket, start, line, column),
+            ']' => self.single_char_token(TokenKind::RBracket, start, line, column),
+            ',' => self.single_char_token(TokenKind::Comma, start, line, column),
+            ':' => self.single_char_token(TokenKind::Colon, start, line, column),
+            ';' => self.single_char_token(TokenKind::Semicolon, start, line, column),
+            '@' => self.single_char_token(TokenKind::At, start, line, column),
+            '#' => self.single_char_token(TokenKind::Hash, start, line, column),
+
+            '+' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::PlusAssign, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Plus, start, start + 1, line, column))
+                }
+            }
+
+            '-' => {
+                self.advance();
+                match self.peek_char() {
+                    Some('=') => {
+                        self.advance();
+                        Some(self.make_token(
+                            TokenKind::MinusAssign,
+                            start,
+                            start + 2,
+                            line,
+                            column,
+                        ))
+                    }
+                    Some('>') => {
+                        self.advance();
+                        Some(self.make_token(TokenKind::Arrow, start, start + 2, line, column))
+                    }
+                    _ => Some(self.make_token(TokenKind::Minus, start, start + 1, line, column)),
+                }
+            }
+
+            '*' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::StarAssign, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Star, start, start + 1, line, column))
+                }
+            }
+
+            '/' => {
+                self.advance();
+                match self.peek_char() {
+                    Some('/') => {
+                        self.skip_line_comment();
+                        self.next_token()
+                    }
+                    Some('*') => {
+                        self.skip_block_comment(line, column);
+                        self.next_token()
+                    }
+                    Some('=') => {
+                        self.advance();
+                        Some(self.make_token(
+                            TokenKind::SlashAssign,
+                            start,
+                            start + 2,
+                            line,
+                            column,
+                        ))
+                    }
+                    _ => Some(self.make_token(TokenKind::Slash, start, start + 1, line, column)),
+                }
+            }
+
+            '%' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::PercentAssign, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Percent, start, start + 1, line, column))
+                }
+            }
+
+            '=' => {
+                self.advance();
+                match self.peek_char() {
+                    Some('=') => {
+                        self.advance();
+                        Some(self.make_token(TokenKind::Eq, start, start + 2, line, column))
+                    }
+                    Some('>') => {
+                        self.advance();
+                        Some(self.make_token(TokenKind::FatArrow, start, start + 2, line, column))
+                    }
+                    _ => Some(self.make_token(TokenKind::Assign, start, start + 1, line, column)),
+                }
+            }
+
+            '!' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::NotEq, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Not, start, start + 1, line, column))
+                }
+            }
+
+            '<' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::LtEq, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Lt, start, start + 1, line, column))
+                }
+            }
+
+            '>' => {
+                self.advance();
+                if self.peek_char() == Some('=') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::GtEq, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Gt, start, start + 1, line, column))
+                }
+            }
+
+            '&' => {
+                self.advance();
+                if self.peek_char() == Some('&') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::And, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Ampersand, start, start + 1, line, column))
+                }
+            }
+
+            '|' => {
+                self.advance();
+                if self.peek_char() == Some('|') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::Or, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Pipe, start, start + 1, line, column))
+                }
+            }
+
+            '?' => {
+                self.advance();
+                match self.peek_char() {
+                    Some('.') => {
+                        self.advance();
+                        Some(self.make_token(
+                            TokenKind::QuestionDot,
+                            start,
+                            start + 2,
+                            line,
+                            column,
+                        ))
+                    }
+                    Some('?') => {
+                        self.advance();
+                        Some(self.make_token(
+                            TokenKind::DoubleQuestion,
+                            start,
+                            start + 2,
+                            line,
+                            column,
+                        ))
+                    }
+                    _ => Some(self.make_token(
+                        TokenKind::QuestionMark,
+                        start,
+                        start + 1,
+                        line,
+                        column,
+                    )),
+                }
+            }
+
+            '.' => {
+                self.advance();
+                if self.peek_char() == Some('.') {
+                    self.advance();
+                    Some(self.make_token(TokenKind::DotDot, start, start + 2, line, column))
+                } else {
+                    Some(self.make_token(TokenKind::Dot, start, start + 1, line, column))
+                }
+            }
+
+            '"' => self.lex_string(start, line, column),
+
+            c if c.is_ascii_digit() => self.lex_number(start, line, column),
+
+            c if c.is_ascii_alphabetic() || c == '_' => self.lex_identifier(start, line, column),
+
+            _ => {
+                self.advance();
+                self.errors.push(LexerError {
+                    message: format!("Unexpected character '{}'", ch),
+                    line,
+                    column,
+                });
+                self.next_token()
+            }
+        }
+    }
+
+    fn advance(&mut self) -> Option<(usize, char)> {
+        let result = self.chars.next();
+        if let Some((_, ch)) = result {
+            if ch == '\n' {
+                self.line += 1;
+                self.column = 1;
+            } else {
+                self.column += 1;
+            }
+        }
+        result
+    }
+
+    fn peek_char(&mut self) -> Option<char> {
+        self.chars.peek().map(|(_, ch)| *ch)
+    }
+
+    fn skip_whitespace(&mut self) {
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch == ' ' || ch == '\t' || ch == '\r' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn skip_line_comment(&mut self) {
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch == '\n' {
+                break;
+            }
+            self.advance();
+        }
+    }
+
+    fn skip_block_comment(&mut self, start_line: usize, start_column: usize) {
+        self.advance(); // consume the '*' after '/'
+        let mut depth = 1;
+
+        while depth > 0 {
+            match self.advance() {
+                Some((_, '/')) => {
+                    if self.peek_char() == Some('*') {
+                        self.advance();
+                        depth += 1;
+                    }
+                }
+                Some((_, '*')) => {
+                    if self.peek_char() == Some('/') {
+                        self.advance();
+                        depth -= 1;
+                    }
+                }
+                None => {
+                    self.errors.push(LexerError {
+                        message: "Unterminated block comment".to_string(),
+                        line: start_line,
+                        column: start_column,
+                    });
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn single_char_token(
+        &mut self,
+        kind: TokenKind,
+        start: usize,
+        line: usize,
+        column: usize,
+    ) -> Option<Token> {
+        let (_, ch) = self.advance().unwrap();
+        Some(self.make_token(kind, start, start + ch.len_utf8(), line, column))
+    }
+
+    fn make_token(
+        &self,
+        kind: TokenKind,
+        start: usize,
+        end: usize,
+        line: usize,
+        column: usize,
+    ) -> Token {
+        Token {
+            kind,
+            span: Span {
+                start,
+                end,
+                line,
+                column,
+            },
+        }
+    }
+
+    fn lex_number(&mut self, start: usize, line: usize, column: usize) -> Option<Token> {
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch.is_ascii_digit() {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        // Check for float
+        if self.peek_char() == Some('.') {
+            // Look ahead past the dot - if the next char is also a dot, it's a range (..)
+            let source_bytes = self.source.as_bytes();
+            let current_pos = self
+                .chars
+                .peek()
+                .map(|(i, _)| *i)
+                .unwrap_or(self.source.len());
+            let after_dot = current_pos + 1;
+
+            if after_dot < source_bytes.len() && source_bytes[after_dot] == b'.' {
+                // It's a range like 3..10, don't consume the dots
+                let text = &self.source[start..current_pos];
+                let value: i64 = match text.parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        self.errors.push(LexerError {
+                            message: format!("Integer literal '{}' is too large", text),
+                            line,
+                            column,
+                        });
+                        0
+                    }
+                };
+                return Some(self.make_token(
+                    TokenKind::IntLiteral(value),
+                    start,
+                    current_pos,
+                    line,
+                    column,
+                ));
+            }
+
+            if after_dot < source_bytes.len() && source_bytes[after_dot].is_ascii_digit() {
+                self.advance(); // consume the '.'
+                while let Some(&(_, ch)) = self.chars.peek() {
+                    if ch.is_ascii_digit() {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                let end = self
+                    .chars
+                    .peek()
+                    .map(|(i, _)| *i)
+                    .unwrap_or(self.source.len());
+                let text = &self.source[start..end];
+                let value: f64 = match text.parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        self.errors.push(LexerError {
+                            message: format!("Invalid float literal '{}'", text),
+                            line,
+                            column,
+                        });
+                        0.0
+                    }
+                };
+                return Some(self.make_token(
+                    TokenKind::FloatLiteral(value),
+                    start,
+                    end,
+                    line,
+                    column,
+                ));
+            }
+        }
+
+        let end = self
+            .chars
+            .peek()
+            .map(|(i, _)| *i)
+            .unwrap_or(self.source.len());
+        let text = &self.source[start..end];
+        let value: i64 = match text.parse() {
+            Ok(v) => v,
+            Err(_) => {
+                self.errors.push(LexerError {
+                    message: format!("Integer literal '{}' is too large", text),
+                    line,
+                    column,
+                });
+                0
+            }
+        };
+        Some(self.make_token(TokenKind::IntLiteral(value), start, end, line, column))
+    }
+
+    fn lex_string(&mut self, start: usize, line: usize, column: usize) -> Option<Token> {
+        self.advance(); // consume opening '"'
+
+        let mut result: Vec<Token> = Vec::new();
+        let mut current_string = String::new();
+        let mut string_segment_start = start + 1;
+        let mut has_interpolation = false;
+
+        loop {
+            match self.chars.peek() {
+                None => {
+                    self.errors.push(LexerError {
+                        message: "Unterminated string literal".to_string(),
+                        line,
+                        column,
+                    });
+                    break;
+                }
+                Some(&(_, '"')) => {
+                    self.advance();
+                    break;
+                }
+                Some(&(pos, '{')) => {
+                    has_interpolation = true;
+
+                    // Push the string part before the interpolation
+                    if !current_string.is_empty() {
+                        result.push(self.make_token(
+                            TokenKind::StringLiteral(current_string.clone()),
+                            string_segment_start,
+                            pos,
+                            line,
+                            column,
+                        ));
+                        current_string.clear();
+                    }
+
+                    self.advance(); // consume '{'
+                    result.push(self.make_token(
+                        TokenKind::InterpolationStart,
+                        pos,
+                        pos + 1,
+                        self.line,
+                        self.column,
+                    ));
+
+                    // Lex tokens inside the interpolation until we hit '}'
+                    let mut brace_depth = 1;
+                    while brace_depth > 0 {
+                        self.skip_whitespace();
+                        match self.chars.peek() {
+                            None => {
+                                self.errors.push(LexerError {
+                                    message: "Unterminated string interpolation".to_string(),
+                                    line,
+                                    column,
+                                });
+                                return result.into_iter().next().or(Some(self.make_token(
+                                    TokenKind::EOF,
+                                    start,
+                                    start,
+                                    line,
+                                    column,
+                                )));
+                            }
+                            Some(&(end_pos, '}')) => {
+                                brace_depth -= 1;
+                                if brace_depth == 0 {
+                                    self.advance();
+                                    result.push(self.make_token(
+                                        TokenKind::InterpolationEnd,
+                                        end_pos,
+                                        end_pos + 1,
+                                        self.line,
+                                        self.column,
+                                    ));
+                                    // Track where the next string segment starts
+                                    string_segment_start = end_pos + 1;
+                                } else if let Some(token) = self.next_token() {
+                                    result.push(token);
+                                }
+                            }
+                            Some(&(_, '{')) => {
+                                brace_depth += 1;
+                                if let Some(token) = self.next_token() {
+                                    result.push(token);
+                                }
+                            }
+                            _ => {
+                                if let Some(token) = self.next_token() {
+                                    result.push(token);
+                                }
+                            }
+                        }
+                    }
+                }
+                Some(&(_, '\\')) => {
+                    self.advance();
+                    match self.chars.peek() {
+                        Some(&(_, 'n')) => {
+                            self.advance();
+                            current_string.push('\n');
+                        }
+                        Some(&(_, 't')) => {
+                            self.advance();
+                            current_string.push('\t');
+                        }
+                        Some(&(_, '\\')) => {
+                            self.advance();
+                            current_string.push('\\');
+                        }
+                        Some(&(_, '"')) => {
+                            self.advance();
+                            current_string.push('"');
+                        }
+                        Some(&(_, '{')) => {
+                            self.advance();
+                            current_string.push('{');
+                        }
+                        Some(&(_, c)) => {
+                            self.advance();
+                            self.errors.push(LexerError {
+                                message: format!("Unknown escape sequence '\\{}'", c),
+                                line: self.line,
+                                column: self.column - 1,
+                            });
+                            current_string.push(c);
+                        }
+                        None => {
+                            self.errors.push(LexerError {
+                                message: "Unterminated escape sequence".to_string(),
+                                line: self.line,
+                                column: self.column,
+                            });
+                        }
+                    }
+                }
+                Some(&(_, ch)) => {
+                    self.advance();
+                    current_string.push(ch);
+                }
+            }
+        }
+
+        if has_interpolation {
+            if !current_string.is_empty() {
+                let end = self
+                    .chars
+                    .peek()
+                    .map(|(i, _)| *i)
+                    .unwrap_or(self.source.len());
+                result.push(self.make_token(
+                    TokenKind::StringLiteral(current_string),
+                    string_segment_start,
+                    end,
+                    self.line,
+                    self.column,
+                ));
+            }
+
+            if result.len() == 1 {
+                return result.into_iter().next();
+            }
+
+            let mut iter = result.into_iter();
+            let first = iter.next();
+            self.pending_tokens = iter.collect::<VecDeque<_>>();
+            return first;
+        }
+
+        let end = self
+            .chars
+            .peek()
+            .map(|(i, _)| *i)
+            .unwrap_or(self.source.len());
+        Some(self.make_token(
+            TokenKind::StringLiteral(current_string),
+            start,
+            end,
+            line,
+            column,
+        ))
+    }
+
+    fn lex_identifier(&mut self, start: usize, line: usize, column: usize) -> Option<Token> {
+        while let Some(&(_, ch)) = self.chars.peek() {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        let end = self
+            .chars
+            .peek()
+            .map(|(i, _)| *i)
+            .unwrap_or(self.source.len());
+        let text = &self.source[start..end];
+
+        let kind = TokenKind::lookup_keyword(text)
+            .unwrap_or_else(|| TokenKind::Identifier(text.to_string()));
+
+        Some(self.make_token(kind, start, end, line, column))
+    }
+}

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,0 +1,148 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+    pub line: usize,
+    pub column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenKind {
+    // Literals
+    IntLiteral(i64),
+    FloatLiteral(f64),
+    StringLiteral(String),
+
+    // String interpolation
+    InterpolationStart,
+    InterpolationEnd,
+
+    // Identifiers & Keywords
+    Identifier(String),
+    Fn,
+    Let,
+    Mut,
+    Return,
+    If,
+    Else,
+    Match,
+    For,
+    While,
+    In,
+    Spawn,
+    Parallel,
+    Scope,
+    Struct,
+    Trait,
+    Impl,
+    Test,
+    Import,
+    Try,
+    Catch,
+    Agent,
+    Module,
+    True,
+    False,
+
+    // Type keywords
+    I32,
+    I64,
+    F32,
+    F64,
+    Str,
+    Bool,
+
+    // Operators
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Percent,
+    Eq,
+    NotEq,
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+    And,
+    Or,
+    Not,
+    Assign,
+    PlusAssign,
+    MinusAssign,
+    StarAssign,
+    SlashAssign,
+    PercentAssign,
+    Arrow,
+    FatArrow,
+    QuestionMark,
+    QuestionDot,
+    DoubleQuestion,
+    Dot,
+    DotDot,
+
+    // Delimiters
+    LParen,
+    RParen,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Comma,
+    Colon,
+    Semicolon,
+
+    // Special
+    At,
+    Pipe,
+    Ampersand,
+    Hash,
+
+    // Meta
+    Newline,
+    EOF,
+}
+
+impl TokenKind {
+    pub fn lookup_keyword(ident: &str) -> Option<TokenKind> {
+        match ident {
+            "fn" => Some(TokenKind::Fn),
+            "let" => Some(TokenKind::Let),
+            "mut" => Some(TokenKind::Mut),
+            "return" => Some(TokenKind::Return),
+            "if" => Some(TokenKind::If),
+            "else" => Some(TokenKind::Else),
+            "match" => Some(TokenKind::Match),
+            "for" => Some(TokenKind::For),
+            "while" => Some(TokenKind::While),
+            "in" => Some(TokenKind::In),
+            "spawn" => Some(TokenKind::Spawn),
+            "parallel" => Some(TokenKind::Parallel),
+            "scope" => Some(TokenKind::Scope),
+            "struct" => Some(TokenKind::Struct),
+            "trait" => Some(TokenKind::Trait),
+            "impl" => Some(TokenKind::Impl),
+            "test" => Some(TokenKind::Test),
+            "import" => Some(TokenKind::Import),
+            "try" => Some(TokenKind::Try),
+            "catch" => Some(TokenKind::Catch),
+            "agent" => Some(TokenKind::Agent),
+            "module" => Some(TokenKind::Module),
+            "true" => Some(TokenKind::True),
+            "false" => Some(TokenKind::False),
+            "i32" => Some(TokenKind::I32),
+            "i64" => Some(TokenKind::I64),
+            "f32" => Some(TokenKind::F32),
+            "f64" => Some(TokenKind::F64),
+            "str" => Some(TokenKind::Str),
+            "bool" => Some(TokenKind::Bool),
+            _ => None,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use sage::lexer::Lexer;
 
 #[derive(Parser)]
 #[command(
@@ -49,7 +50,35 @@ fn main() {
 
     match cli.command {
         Commands::Build { file } => {
-            println!("sage build: not implemented yet (file: {})", file);
+            let source = match std::fs::read_to_string(&file) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Error reading '{}': {}", file, e);
+                    std::process::exit(1);
+                }
+            };
+
+            let mut lexer = Lexer::new(&source);
+            let tokens = lexer.tokenize();
+
+            for error in lexer.errors() {
+                eprintln!("{}", error);
+            }
+
+            if !lexer.errors().is_empty() {
+                std::process::exit(1);
+            }
+
+            println!("Lexed {} tokens from '{}'", tokens.len(), file);
+            for token in &tokens {
+                println!(
+                    "  {:>4}:{:<3} {:?}",
+                    token.span.line, token.span.column, token.kind
+                );
+            }
+
+            // TODO: parser, type checker, codegen
+            println!("\nParser not implemented yet.");
         }
         Commands::Run { file } => {
             println!("sage run: not implemented yet (file: {})", file);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -13,14 +13,15 @@ fn version_prints_sage() {
 }
 
 #[test]
-fn build_stub_prints_not_implemented() {
+fn build_lexes_hello_sg() {
     let output = Command::new(env!("CARGO_BIN_EXE_sage"))
         .args(["build", "examples/hello.sg"])
         .output()
         .expect("failed to run sage");
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("not implemented yet"));
+    assert!(stdout.contains("Lexed"));
+    assert!(stdout.contains("tokens"));
 }
 
 #[test]

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -1,0 +1,575 @@
+use sage::lexer::Lexer;
+use sage::lexer::token::TokenKind;
+
+fn token_kinds(source: &str) -> Vec<TokenKind> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize();
+    tokens.into_iter().map(|t| t.kind).collect()
+}
+
+#[test]
+fn lex_simple_expression() {
+    let kinds = token_kinds("1 + 2 * 3");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::IntLiteral(1),
+            TokenKind::Plus,
+            TokenKind::IntLiteral(2),
+            TokenKind::Star,
+            TokenKind::IntLiteral(3),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_variable_declaration() {
+    let kinds = token_kinds("let x: i32 = 42");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Let,
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Colon,
+            TokenKind::I32,
+            TokenKind::Assign,
+            TokenKind::IntLiteral(42),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_mutable_variable() {
+    let kinds = token_kinds("let mut count = 0");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Let,
+            TokenKind::Mut,
+            TokenKind::Identifier("count".to_string()),
+            TokenKind::Assign,
+            TokenKind::IntLiteral(0),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_function_definition() {
+    let kinds = token_kinds("fn add(a: i32, b: i32) -> i32 { return a + b }");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Fn,
+            TokenKind::Identifier("add".to_string()),
+            TokenKind::LParen,
+            TokenKind::Identifier("a".to_string()),
+            TokenKind::Colon,
+            TokenKind::I32,
+            TokenKind::Comma,
+            TokenKind::Identifier("b".to_string()),
+            TokenKind::Colon,
+            TokenKind::I32,
+            TokenKind::RParen,
+            TokenKind::Arrow,
+            TokenKind::I32,
+            TokenKind::LBrace,
+            TokenKind::Return,
+            TokenKind::Identifier("a".to_string()),
+            TokenKind::Plus,
+            TokenKind::Identifier("b".to_string()),
+            TokenKind::RBrace,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_float_literal() {
+    let kinds = token_kinds("3.14");
+    assert_eq!(kinds, vec![TokenKind::FloatLiteral(3.14), TokenKind::EOF,]);
+}
+
+#[test]
+fn lex_range_not_float() {
+    let kinds = token_kinds("3..10");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::IntLiteral(3),
+            TokenKind::DotDot,
+            TokenKind::IntLiteral(10),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_string_literal() {
+    let kinds = token_kinds("\"hello world\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::StringLiteral("hello world".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_string_escape_sequences() {
+    let kinds = token_kinds("\"hello\\nworld\\t!\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::StringLiteral("hello\nworld\t!".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_string_interpolation() {
+    let kinds = token_kinds("\"Hello {name}!\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::StringLiteral("Hello ".to_string()),
+            TokenKind::InterpolationStart,
+            TokenKind::Identifier("name".to_string()),
+            TokenKind::InterpolationEnd,
+            TokenKind::StringLiteral("!".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_multi_char_operators() {
+    let kinds = token_kinds("-> => .. ?. ?? += -= *= /= == != <= >=");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Arrow,
+            TokenKind::FatArrow,
+            TokenKind::DotDot,
+            TokenKind::QuestionDot,
+            TokenKind::DoubleQuestion,
+            TokenKind::PlusAssign,
+            TokenKind::MinusAssign,
+            TokenKind::StarAssign,
+            TokenKind::SlashAssign,
+            TokenKind::Eq,
+            TokenKind::NotEq,
+            TokenKind::LtEq,
+            TokenKind::GtEq,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_logical_operators() {
+    let kinds = token_kinds("a && b || !c");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("a".to_string()),
+            TokenKind::And,
+            TokenKind::Identifier("b".to_string()),
+            TokenKind::Or,
+            TokenKind::Not,
+            TokenKind::Identifier("c".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_line_comment() {
+    let kinds = token_kinds("x + y // this is a comment\nz");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Plus,
+            TokenKind::Identifier("y".to_string()),
+            TokenKind::Newline,
+            TokenKind::Identifier("z".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_block_comment() {
+    let kinds = token_kinds("x + /* comment */ y");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Plus,
+            TokenKind::Identifier("y".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_nested_block_comment() {
+    let kinds = token_kinds("x /* outer /* inner */ still comment */ y");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Identifier("y".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_keywords() {
+    let kinds = token_kinds("fn let mut return if else match for while in struct trait impl");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Fn,
+            TokenKind::Let,
+            TokenKind::Mut,
+            TokenKind::Return,
+            TokenKind::If,
+            TokenKind::Else,
+            TokenKind::Match,
+            TokenKind::For,
+            TokenKind::While,
+            TokenKind::In,
+            TokenKind::Struct,
+            TokenKind::Trait,
+            TokenKind::Impl,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_sage_keywords() {
+    let kinds = token_kinds("spawn parallel scope agent module try catch import test");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Spawn,
+            TokenKind::Parallel,
+            TokenKind::Scope,
+            TokenKind::Agent,
+            TokenKind::Module,
+            TokenKind::Try,
+            TokenKind::Catch,
+            TokenKind::Import,
+            TokenKind::Test,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_booleans() {
+    let kinds = token_kinds("true false");
+    assert_eq!(
+        kinds,
+        vec![TokenKind::True, TokenKind::False, TokenKind::EOF,]
+    );
+}
+
+#[test]
+fn lex_type_keywords() {
+    let kinds = token_kinds("i32 i64 f32 f64 str bool");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::I32,
+            TokenKind::I64,
+            TokenKind::F32,
+            TokenKind::F64,
+            TokenKind::Str,
+            TokenKind::Bool,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_decorator() {
+    let kinds = token_kinds("@mcp_server");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::At,
+            TokenKind::Identifier("mcp_server".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_struct_definition() {
+    let kinds = token_kinds("struct User { name: str, age: i32 }");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Struct,
+            TokenKind::Identifier("User".to_string()),
+            TokenKind::LBrace,
+            TokenKind::Identifier("name".to_string()),
+            TokenKind::Colon,
+            TokenKind::Str,
+            TokenKind::Comma,
+            TokenKind::Identifier("age".to_string()),
+            TokenKind::Colon,
+            TokenKind::I32,
+            TokenKind::RBrace,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_match_expression() {
+    let kinds = token_kinds("match x { 1 => 2 }");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Match,
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::LBrace,
+            TokenKind::IntLiteral(1),
+            TokenKind::FatArrow,
+            TokenKind::IntLiteral(2),
+            TokenKind::RBrace,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_null_safety() {
+    let kinds = token_kinds("user?.name ?? \"Unknown\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("user".to_string()),
+            TokenKind::QuestionDot,
+            TokenKind::Identifier("name".to_string()),
+            TokenKind::DoubleQuestion,
+            TokenKind::StringLiteral("Unknown".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_empty_source() {
+    let kinds = token_kinds("");
+    assert_eq!(kinds, vec![TokenKind::EOF]);
+}
+
+#[test]
+fn lex_hello_world() {
+    let source = "fn main() {\n    println(\"Hello, Sage!\")\n}";
+    let kinds = token_kinds(source);
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Fn,
+            TokenKind::Identifier("main".to_string()),
+            TokenKind::LParen,
+            TokenKind::RParen,
+            TokenKind::LBrace,
+            TokenKind::Newline,
+            TokenKind::Identifier("println".to_string()),
+            TokenKind::LParen,
+            TokenKind::StringLiteral("Hello, Sage!".to_string()),
+            TokenKind::RParen,
+            TokenKind::Newline,
+            TokenKind::RBrace,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_error_unexpected_character() {
+    let mut lexer = Lexer::new("x $ y");
+    lexer.tokenize();
+    assert_eq!(lexer.errors().len(), 1);
+    assert!(
+        lexer.errors()[0]
+            .message
+            .contains("Unexpected character '$'")
+    );
+}
+
+#[test]
+fn lex_error_unterminated_string() {
+    let mut lexer = Lexer::new("\"hello");
+    lexer.tokenize();
+    assert_eq!(lexer.errors().len(), 1);
+    assert!(
+        lexer.errors()[0]
+            .message
+            .contains("Unterminated string literal")
+    );
+}
+
+#[test]
+fn lex_span_tracking() {
+    let mut lexer = Lexer::new("let x = 42");
+    let tokens = lexer.tokenize();
+
+    assert_eq!(tokens[0].span.line, 1);
+    assert_eq!(tokens[0].span.column, 1);
+
+    // 'x' is at column 5
+    assert_eq!(tokens[1].span.line, 1);
+    assert_eq!(tokens[1].span.column, 5);
+}
+
+#[test]
+fn lex_multiline_span_tracking() {
+    let mut lexer = Lexer::new("let x = 1\nlet y = 2");
+    let tokens = lexer.tokenize();
+
+    // 'let' on line 2
+    let second_let = tokens
+        .iter()
+        .filter(|t| t.kind == TokenKind::Let)
+        .nth(1)
+        .unwrap();
+    assert_eq!(second_let.span.line, 2);
+    assert_eq!(second_let.span.column, 1);
+}
+
+#[test]
+fn lex_ampersand_and_reference() {
+    let kinds = token_kinds("&x &mut y");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Ampersand,
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Ampersand,
+            TokenKind::Mut,
+            TokenKind::Identifier("y".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_question_mark_operator() {
+    let kinds = token_kinds("result?");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("result".to_string()),
+            TokenKind::QuestionMark,
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_pipe_for_closure() {
+    let kinds = token_kinds("|x| x + 1");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Pipe,
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Pipe,
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::Plus,
+            TokenKind::IntLiteral(1),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_escaped_brace_in_string() {
+    let kinds = token_kinds("\"hello \\{world}\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::StringLiteral("hello {world}".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_multiple_interpolations() {
+    let kinds = token_kinds("\"Hello {first} {last}!\"");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::StringLiteral("Hello ".to_string()),
+            TokenKind::InterpolationStart,
+            TokenKind::Identifier("first".to_string()),
+            TokenKind::InterpolationEnd,
+            TokenKind::StringLiteral(" ".to_string()),
+            TokenKind::InterpolationStart,
+            TokenKind::Identifier("last".to_string()),
+            TokenKind::InterpolationEnd,
+            TokenKind::StringLiteral("!".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_integer_overflow_reports_error() {
+    let mut lexer = Lexer::new("99999999999999999999999999999");
+    lexer.tokenize();
+    assert_eq!(lexer.errors().len(), 1);
+    assert!(lexer.errors()[0].message.contains("too large"));
+}
+
+#[test]
+fn lex_underscore_identifiers() {
+    let kinds = token_kinds("_private __internal _");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("_private".to_string()),
+            TokenKind::Identifier("__internal".to_string()),
+            TokenKind::Identifier("_".to_string()),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_percent_assign() {
+    let kinds = token_kinds("x %= 2");
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Identifier("x".to_string()),
+            TokenKind::PercentAssign,
+            TokenKind::IntLiteral(2),
+            TokenKind::EOF,
+        ]
+    );
+}
+
+#[test]
+fn lex_negative_number_as_unary() {
+    let kinds = token_kinds("-42");
+    assert_eq!(
+        kinds,
+        vec![TokenKind::Minus, TokenKind::IntLiteral(42), TokenKind::EOF,]
+    );
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                       
  - Hand-written lexer that tokenizes all Sage syntax: operators (single and multi-char like ->, =>, ?., ??), string interpolation with {expr}, nestable block comments, escape sequences, keyword detection, and span tracking with line/column info                                                  
  - Identifiers restricted to ASCII only (Unicode can be relaxed later without breaking changes)                                                                                                                                                                                                       
  - Error reporting that collects multiple errors per file with exact locations (overflow, unterminated strings, unexpected characters)
  - VecDeque-based token buffer for string interpolation (O(1) pop vs O(n) Vec remove)                                                                                                                                                                                                                 
  - `sage build` now lexes source files and prints the token stream
  - Added PercentAssign (%=) operator, removed unused BoolLiteral variant                                                                                                                                                                                                                              
  - 37 lexer tests + 3 CLI tests all passing, fmt and clippy clean

  ## Test plan

  - `cargo test` passes all 40 tests
  - `cargo fmt -- --check` passes
  - `cargo clippy -- -D warnings` passes
  - `sage build examples/hello.sg` lexes and prints correct token stream

  Closes #3 