### PR TITLE
feat: add AST types and parser scaffold

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Span {
     pub start: usize,
     pub end: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
 
             println!("Parsed {} top-level statements from '{}'", ast.len(), file);
             for stmt in &ast {
-                println!("  {:?}", stmt);
+                println!("  {:?}", stmt.kind);
             }
 
             // TODO: type checker, codegen

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 use sage::lexer::Lexer;
+use sage::parser;
 
 #[derive(Parser)]
 #[command(
@@ -69,16 +70,24 @@ fn main() {
                 std::process::exit(1);
             }
 
-            println!("Lexed {} tokens from '{}'", tokens.len(), file);
-            for token in &tokens {
-                println!(
-                    "  {:>4}:{:<3} {:?}",
-                    token.span.line, token.span.column, token.kind
-                );
+            let mut parser = parser::Parser::new(tokens);
+            let ast = parser.parse();
+
+            for error in parser.errors() {
+                eprintln!("{}", error);
             }
 
-            // TODO: parser, type checker, codegen
-            println!("\nParser not implemented yet.");
+            if !parser.errors().is_empty() {
+                std::process::exit(1);
+            }
+
+            println!("Parsed {} top-level statements from '{}'", ast.len(), file);
+            for stmt in &ast {
+                println!("  {:?}", stmt);
+            }
+
+            // TODO: type checker, codegen
+            println!("\nType checker not implemented yet.");
         }
         Commands::Run { file } => {
             println!("sage run: not implemented yet (file: {})", file);

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,5 +1,7 @@
 // AST node types for the Sage parser
 
+use crate::lexer::token::Span;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum BinOp {
     Add,
@@ -79,8 +81,37 @@ pub enum StringPart {
     Expr(Expr),
 }
 
+/// Expression node: a kind paired with its source location.
+/// PartialEq compares only the kind (ignoring span), so tests can
+/// construct values with `Expr::dummy(kind)` and compare freely.
+#[derive(Debug, Clone)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+impl Expr {
+    pub fn new(kind: ExprKind, span: Span) -> Self {
+        Expr { kind, span }
+    }
+
+    /// Create an Expr with a dummy span (for use in tests).
+    pub fn dummy(kind: ExprKind) -> Self {
+        Expr {
+            kind,
+            span: Span::default(),
+        }
+    }
+}
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
-pub enum Expr {
+pub enum ExprKind {
     IntLiteral(i64),
     FloatLiteral(f64),
     StringLiteral(String),
@@ -154,8 +185,35 @@ pub enum Expr {
     },
 }
 
+/// Statement node: a kind paired with its source location.
+/// PartialEq compares only the kind (ignoring span).
+#[derive(Debug, Clone)]
+pub struct Stmt {
+    pub kind: StmtKind,
+    pub span: Span,
+}
+
+impl Stmt {
+    pub fn new(kind: StmtKind, span: Span) -> Self {
+        Stmt { kind, span }
+    }
+
+    pub fn dummy(kind: StmtKind) -> Self {
+        Stmt {
+            kind,
+            span: Span::default(),
+        }
+    }
+}
+
+impl PartialEq for Stmt {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
-pub enum Stmt {
+pub enum StmtKind {
     Let {
         name: String,
         mutable: bool,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,0 +1,216 @@
+// AST node types for the Sage parser
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Eq,
+    NotEq,
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+    And,
+    Or,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnOp {
+    Neg,
+    Not,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Type {
+    Simple(String),
+    Nullable(Box<Type>),
+    Generic {
+        name: String,
+        params: Vec<Type>,
+    },
+    Reference {
+        mutable: bool,
+        inner: Box<Type>,
+    },
+    Function {
+        params: Vec<Type>,
+        return_type: Box<Type>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Param {
+    pub name: String,
+    pub type_ann: Option<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Field {
+    pub name: String,
+    pub type_ann: Type,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchArm {
+    pub pattern: Expr,
+    pub body: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Decorator {
+    pub name: String,
+    pub args: Vec<(String, Expr)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FnSignature {
+    pub name: String,
+    pub params: Vec<Param>,
+    pub return_type: Option<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StringPart {
+    Literal(String),
+    Expr(Expr),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    IntLiteral(i64),
+    FloatLiteral(f64),
+    StringLiteral(String),
+    BoolLiteral(bool),
+    Identifier(String),
+    BinaryOp {
+        left: Box<Expr>,
+        op: BinOp,
+        right: Box<Expr>,
+    },
+    UnaryOp {
+        op: UnOp,
+        expr: Box<Expr>,
+    },
+    FnCall {
+        callee: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    MethodCall {
+        object: Box<Expr>,
+        method: String,
+        args: Vec<Expr>,
+    },
+    FieldAccess {
+        object: Box<Expr>,
+        field: String,
+    },
+    Index {
+        object: Box<Expr>,
+        index: Box<Expr>,
+    },
+    Match {
+        expr: Box<Expr>,
+        arms: Vec<MatchArm>,
+    },
+    IfElse {
+        condition: Box<Expr>,
+        then_block: Vec<Stmt>,
+        else_block: Option<Vec<Stmt>>,
+    },
+    Closure {
+        params: Vec<Param>,
+        body: Vec<Stmt>,
+    },
+    ListLiteral(Vec<Expr>),
+    ListComprehension {
+        expr: Box<Expr>,
+        var: String,
+        iter: Box<Expr>,
+        filter: Option<Box<Expr>>,
+    },
+    Spawn(Box<Expr>),
+    Parallel {
+        collection: Box<Expr>,
+        param: String,
+        body: Box<Expr>,
+    },
+    Scope {
+        body: Vec<Stmt>,
+    },
+    NullCoalesce {
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
+    SafeAccess {
+        object: Box<Expr>,
+        field: String,
+    },
+    StringInterpolation {
+        parts: Vec<StringPart>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Stmt {
+    Let {
+        name: String,
+        mutable: bool,
+        type_ann: Option<Type>,
+        value: Expr,
+    },
+    FnDef {
+        name: String,
+        params: Vec<Param>,
+        return_type: Option<Type>,
+        body: Vec<Stmt>,
+        decorators: Vec<Decorator>,
+    },
+    StructDef {
+        name: String,
+        fields: Vec<Field>,
+    },
+    TraitDef {
+        name: String,
+        methods: Vec<FnSignature>,
+    },
+    ImplBlock {
+        trait_name: Option<String>,
+        target: String,
+        methods: Vec<Stmt>,
+    },
+    Return(Option<Expr>),
+    Expression(Expr),
+    ForLoop {
+        var: String,
+        iter: Expr,
+        body: Vec<Stmt>,
+    },
+    WhileLoop {
+        condition: Expr,
+        body: Vec<Stmt>,
+    },
+    Import {
+        path: Vec<String>,
+    },
+    TryCatch {
+        try_block: Vec<Stmt>,
+        catch_var: String,
+        catch_block: Vec<Stmt>,
+    },
+    TestFn {
+        name: String,
+        body: Vec<Stmt>,
+    },
+    AgentDef {
+        name: String,
+        config: Vec<(String, Expr)>,
+    },
+    ModuleDef {
+        name: String,
+        decorators: Vec<Decorator>,
+        body: Vec<Stmt>,
+    },
+}

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -15,6 +15,7 @@ pub enum BinOp {
     GtEq,
     And,
     Or,
+    Range,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,8 +61,146 @@ impl Parser {
     // -- Statement parsing --
 
     fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
+        match self.peek() {
+            TokenKind::Let => self.parse_let(),
+            TokenKind::Return => self.parse_return(),
+            _ => {
+                let expr = self.parse_expr(0)?;
+                Ok(Stmt::Expression(expr))
+            }
+        }
+    }
+
+    fn parse_let(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'let'
+
+        let mutable = if self.at(&TokenKind::Mut) {
+            self.advance();
+            true
+        } else {
+            false
+        };
+
+        let name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected variable name after 'let'".to_string())),
+        };
+
+        let type_ann = if self.at(&TokenKind::Colon) {
+            self.advance();
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+
+        self.expect(&TokenKind::Assign)?;
+        let value = self.parse_expr(0)?;
+
+        Ok(Stmt::Let {
+            name,
+            mutable,
+            type_ann,
+            value,
+        })
+    }
+
+    fn parse_return(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'return'
+
+        // return with no value: next token is newline, }, or EOF
+        if matches!(
+            self.peek(),
+            TokenKind::Newline | TokenKind::RBrace | TokenKind::EOF
+        ) {
+            return Ok(Stmt::Return(None));
+        }
+
         let expr = self.parse_expr(0)?;
-        Ok(Stmt::Expression(expr))
+        Ok(Stmt::Return(Some(expr)))
+    }
+
+    // -- Type parsing --
+
+    fn parse_type(&mut self) -> Result<Type, ParseError> {
+        let ty = match self.peek().clone() {
+            TokenKind::Ampersand => {
+                self.advance();
+                let mutable = if self.at(&TokenKind::Mut) {
+                    self.advance();
+                    true
+                } else {
+                    false
+                };
+                let inner = self.parse_type()?;
+                Type::Reference {
+                    mutable,
+                    inner: Box::new(inner),
+                }
+            }
+            TokenKind::Identifier(name) => {
+                self.advance();
+                self.parse_type_suffix(name)?
+            }
+            // Type keywords: i32, i64, f32, f64, str, bool
+            TokenKind::I32 => {
+                self.advance();
+                self.parse_type_suffix("i32".to_string())?
+            }
+            TokenKind::I64 => {
+                self.advance();
+                self.parse_type_suffix("i64".to_string())?
+            }
+            TokenKind::F32 => {
+                self.advance();
+                self.parse_type_suffix("f32".to_string())?
+            }
+            TokenKind::F64 => {
+                self.advance();
+                self.parse_type_suffix("f64".to_string())?
+            }
+            TokenKind::Str => {
+                self.advance();
+                self.parse_type_suffix("str".to_string())?
+            }
+            TokenKind::Bool => {
+                self.advance();
+                self.parse_type_suffix("bool".to_string())?
+            }
+            _ => return Err(self.error(format!("Expected type, found {:?}", self.peek()))),
+        };
+
+        Ok(ty)
+    }
+
+    fn parse_type_suffix(&mut self, name: String) -> Result<Type, ParseError> {
+        // Check for generic params: Name<T, U>
+        if self.at(&TokenKind::Lt) {
+            self.advance();
+            let mut params = vec![self.parse_type()?];
+            while self.at(&TokenKind::Comma) {
+                self.advance();
+                params.push(self.parse_type()?);
+            }
+            self.expect(&TokenKind::Gt)?;
+            let ty = Type::Generic { name, params };
+            // Check for ? after generic
+            if self.at(&TokenKind::QuestionMark) {
+                self.advance();
+                return Ok(Type::Nullable(Box::new(ty)));
+            }
+            return Ok(ty);
+        }
+
+        // Check for nullable: Name?
+        if self.at(&TokenKind::QuestionMark) {
+            self.advance();
+            return Ok(Type::Nullable(Box::new(Type::Simple(name))));
+        }
+
+        Ok(Type::Simple(name))
     }
 
     // -- Pratt expression parsing --

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -65,6 +65,8 @@ impl Parser {
             TokenKind::Let => self.parse_let(),
             TokenKind::Return => self.parse_return(),
             TokenKind::Fn => self.parse_fn(vec![]),
+            TokenKind::For => self.parse_for(),
+            TokenKind::While => self.parse_while(),
             _ => {
                 let expr = self.parse_expr(0)?;
                 Ok(Stmt::Expression(expr))
@@ -296,7 +298,7 @@ impl Parser {
 
             // Postfix: function call
             if op == TokenKind::LParen {
-                if 15 < min_bp {
+                if 17 < min_bp {
                     break;
                 }
                 let args = self.parse_args()?;
@@ -309,7 +311,7 @@ impl Parser {
 
             // Postfix: index access
             if op == TokenKind::LBracket {
-                if 15 < min_bp {
+                if 17 < min_bp {
                     break;
                 }
                 self.advance();
@@ -324,7 +326,7 @@ impl Parser {
 
             // Postfix: field access / method call
             if op == TokenKind::Dot {
-                if 15 < min_bp {
+                if 17 < min_bp {
                     break;
                 }
                 self.advance();
@@ -354,7 +356,7 @@ impl Parser {
 
             // Postfix: safe access
             if op == TokenKind::QuestionDot {
-                if 15 < min_bp {
+                if 17 < min_bp {
                     break;
                 }
                 self.advance();
@@ -460,8 +462,93 @@ impl Parser {
                     expr: Box::new(expr),
                 })
             }
+            TokenKind::If => self.parse_if(),
+            TokenKind::Match => self.parse_match(),
             _ => Err(self.error(format!("Expected expression, found {:?}", self.peek()))),
         }
+    }
+
+    // -- Control flow --
+
+    fn parse_if(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume 'if'
+
+        let condition = self.parse_expr(0)?;
+        let then_block = self.parse_block()?;
+
+        let else_block = if self.at(&TokenKind::Else) {
+            self.advance();
+            if self.at(&TokenKind::If) {
+                // else if -> the else block is a single expression statement containing another if
+                let nested_if = self.parse_if()?;
+                Some(vec![Stmt::Expression(nested_if)])
+            } else {
+                Some(self.parse_block()?)
+            }
+        } else {
+            None
+        };
+
+        Ok(Expr::IfElse {
+            condition: Box::new(condition),
+            then_block,
+            else_block,
+        })
+    }
+
+    fn parse_match(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume 'match'
+
+        let matched = self.parse_expr(0)?;
+        self.expect(&TokenKind::LBrace)?;
+        self.skip_newlines();
+
+        let mut arms = Vec::new();
+        while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
+            let pattern = self.parse_expr(0)?;
+            self.expect(&TokenKind::FatArrow)?;
+            let body = self.parse_expr(0)?;
+            arms.push(MatchArm { pattern, body });
+
+            // Arms separated by commas or newlines
+            if self.at(&TokenKind::Comma) {
+                self.advance();
+            }
+            self.skip_newlines();
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Expr::Match {
+            expr: Box::new(matched),
+            arms,
+        })
+    }
+
+    fn parse_for(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'for'
+
+        let var = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected variable name after 'for'".to_string())),
+        };
+
+        self.expect(&TokenKind::In)?;
+        let iter = self.parse_expr(0)?;
+        let body = self.parse_block()?;
+
+        Ok(Stmt::ForLoop { var, iter, body })
+    }
+
+    fn parse_while(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'while'
+
+        let condition = self.parse_expr(0)?;
+        let body = self.parse_block()?;
+
+        Ok(Stmt::WhileLoop { condition, body })
     }
 
     fn make_binary(&self, left: Expr, op: &TokenKind, right: Expr) -> Expr {
@@ -479,6 +566,7 @@ impl Parser {
             TokenKind::GtEq => BinOp::GtEq,
             TokenKind::And => BinOp::And,
             TokenKind::Or => BinOp::Or,
+            TokenKind::DotDot => BinOp::Range,
             _ => unreachable!("Not a binary operator: {:?}", op),
         };
         Expr::BinaryOp {
@@ -491,7 +579,7 @@ impl Parser {
     // Binding power for prefix (unary) operators
     fn prefix_binding_power(op: &TokenKind) -> u8 {
         match op {
-            TokenKind::Minus | TokenKind::Not => 13,
+            TokenKind::Minus | TokenKind::Not => 15,
             _ => 0,
         }
     }
@@ -501,13 +589,14 @@ impl Parser {
     // Right-associative: right_bp = left_bp - 1
     fn infix_binding_power(op: &TokenKind) -> Option<(u8, u8)> {
         match op {
-            TokenKind::DoubleQuestion => Some((2, 1)), // right-assoc
-            TokenKind::Or => Some((3, 4)),
-            TokenKind::And => Some((5, 6)),
-            TokenKind::Eq | TokenKind::NotEq => Some((7, 8)),
-            TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq => Some((7, 8)),
-            TokenKind::Plus | TokenKind::Minus => Some((9, 10)),
-            TokenKind::Star | TokenKind::Slash | TokenKind::Percent => Some((11, 12)),
+            TokenKind::DotDot => Some((1, 2)),
+            TokenKind::DoubleQuestion => Some((4, 3)), // right-assoc
+            TokenKind::Or => Some((5, 6)),
+            TokenKind::And => Some((7, 8)),
+            TokenKind::Eq | TokenKind::NotEq => Some((9, 10)),
+            TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq => Some((9, 10)),
+            TokenKind::Plus | TokenKind::Minus => Some((11, 12)),
+            TokenKind::Star | TokenKind::Slash | TokenKind::Percent => Some((13, 14)),
             _ => None,
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,1 +1,93 @@
-// Parser - builds an Abstract Syntax Tree from tokens
+#![allow(dead_code)]
+
+pub mod ast;
+
+use crate::lexer::token::{Span, Token, TokenKind};
+
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Parse error: {} at line {}, column {}",
+            self.message, self.span.line, self.span.column
+        )
+    }
+}
+
+pub struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+    errors: Vec<ParseError>,
+}
+
+impl Parser {
+    pub fn new(tokens: Vec<Token>) -> Self {
+        Parser {
+            tokens,
+            pos: 0,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn parse(&mut self) -> Vec<ast::Stmt> {
+        let stmts = Vec::new();
+
+        self.skip_newlines();
+        // Statement parsing will be added in Task 2+
+
+        stmts
+    }
+
+    pub fn errors(&self) -> &[ParseError] {
+        &self.errors
+    }
+
+    // -- Token cursor methods --
+
+    fn peek(&self) -> &TokenKind {
+        &self.tokens[self.pos].kind
+    }
+
+    fn peek_token(&self) -> &Token {
+        &self.tokens[self.pos]
+    }
+
+    fn advance(&mut self) -> &Token {
+        let token = &self.tokens[self.pos];
+        if self.pos < self.tokens.len() - 1 {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn at(&self, kind: &TokenKind) -> bool {
+        std::mem::discriminant(self.peek()) == std::mem::discriminant(kind)
+    }
+
+    fn expect(&mut self, expected: &TokenKind) -> Result<Token, ParseError> {
+        if self.at(expected) {
+            Ok(self.advance().clone())
+        } else {
+            Err(self.error(format!("Expected {:?}, found {:?}", expected, self.peek())))
+        }
+    }
+
+    fn skip_newlines(&mut self) {
+        while self.at(&TokenKind::Newline) {
+            self.advance();
+        }
+    }
+
+    fn error(&self, message: String) -> ParseError {
+        ParseError {
+            message,
+            span: self.peek_token().span.clone(),
+        }
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -45,7 +45,7 @@ impl Parser {
                 Ok(stmt) => stmts.push(stmt),
                 Err(e) => {
                     self.errors.push(e);
-                    break;
+                    self.synchronize();
                 }
             }
             self.skip_newlines();
@@ -978,6 +978,37 @@ impl Parser {
             TokenKind::Plus | TokenKind::Minus => Some((11, 12)),
             TokenKind::Star | TokenKind::Slash | TokenKind::Percent => Some((13, 14)),
             _ => None,
+        }
+    }
+
+    // -- Error recovery --
+
+    fn synchronize(&mut self) {
+        // Skip tokens until we find a statement boundary
+        loop {
+            match self.peek() {
+                TokenKind::EOF => break,
+                // Statement-starting keywords
+                TokenKind::Let
+                | TokenKind::Fn
+                | TokenKind::Struct
+                | TokenKind::Trait
+                | TokenKind::Impl
+                | TokenKind::For
+                | TokenKind::While
+                | TokenKind::Return
+                | TokenKind::Import
+                | TokenKind::Try
+                | TokenKind::Test
+                | TokenKind::At => break,
+                TokenKind::Newline => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.advance();
+                }
+            }
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,15 +61,25 @@ impl Parser {
     // -- Statement parsing --
 
     fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
+        // Collect decorators before the statement
+        let decorators = if self.at(&TokenKind::At) {
+            self.parse_decorators()?
+        } else {
+            vec![]
+        };
+
         match self.peek() {
             TokenKind::Let => self.parse_let(),
             TokenKind::Return => self.parse_return(),
-            TokenKind::Fn => self.parse_fn(vec![]),
+            TokenKind::Fn => self.parse_fn(decorators),
             TokenKind::For => self.parse_for(),
             TokenKind::While => self.parse_while(),
             TokenKind::Struct => self.parse_struct(),
             TokenKind::Trait => self.parse_trait(),
             TokenKind::Impl => self.parse_impl(),
+            TokenKind::Import => self.parse_import(),
+            TokenKind::Try => self.parse_try_catch(),
+            TokenKind::Test => self.parse_test(),
             _ => {
                 let expr = self.parse_expr(0)?;
                 Ok(Stmt::Expression(expr))
@@ -427,7 +437,16 @@ impl Parser {
             }
             TokenKind::StringLiteral(s) => {
                 self.advance();
-                Ok(Expr::StringLiteral(s))
+                // Check if this is the start of string interpolation
+                if self.at(&TokenKind::InterpolationStart) {
+                    self.parse_string_interpolation(s)
+                } else {
+                    Ok(Expr::StringLiteral(s))
+                }
+            }
+            TokenKind::InterpolationStart => {
+                // Interpolation at start of string (empty prefix)
+                self.parse_string_interpolation(String::new())
             }
             TokenKind::True => {
                 self.advance();
@@ -467,6 +486,10 @@ impl Parser {
             }
             TokenKind::If => self.parse_if(),
             TokenKind::Match => self.parse_match(),
+            TokenKind::Pipe => self.parse_closure(),
+            TokenKind::LBracket => self.parse_list_literal(),
+            TokenKind::Spawn => self.parse_spawn(),
+            TokenKind::Parallel => self.parse_parallel(),
             _ => Err(self.error(format!("Expected expression, found {:?}", self.peek()))),
         }
     }
@@ -552,6 +575,226 @@ impl Parser {
         let body = self.parse_block()?;
 
         Ok(Stmt::WhileLoop { condition, body })
+    }
+
+    // -- Decorators, imports, try/catch, test --
+
+    fn parse_decorators(&mut self) -> Result<Vec<Decorator>, ParseError> {
+        let mut decorators = Vec::new();
+
+        while self.at(&TokenKind::At) {
+            self.advance(); // consume '@'
+            let name = match self.peek().clone() {
+                TokenKind::Identifier(name) => {
+                    self.advance();
+                    name
+                }
+                _ => return Err(self.error("Expected decorator name after '@'".to_string())),
+            };
+
+            let args = if self.at(&TokenKind::LParen) {
+                self.advance();
+                let mut args = Vec::new();
+                if !self.at(&TokenKind::RParen) {
+                    loop {
+                        let key = match self.peek().clone() {
+                            TokenKind::Identifier(k) => {
+                                self.advance();
+                                k
+                            }
+                            _ => {
+                                return Err(
+                                    self.error("Expected argument name in decorator".to_string())
+                                );
+                            }
+                        };
+                        self.expect(&TokenKind::Colon)?;
+                        let value = self.parse_expr(0)?;
+                        args.push((key, value));
+                        if !self.at(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.advance();
+                    }
+                }
+                self.expect(&TokenKind::RParen)?;
+                args
+            } else {
+                vec![]
+            };
+
+            decorators.push(Decorator { name, args });
+            self.skip_newlines();
+        }
+
+        Ok(decorators)
+    }
+
+    fn parse_import(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'import'
+
+        let mut path = Vec::new();
+        let first = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected module path after 'import'".to_string())),
+        };
+        path.push(first);
+
+        while self.at(&TokenKind::Dot) {
+            self.advance();
+            let segment = match self.peek().clone() {
+                TokenKind::Identifier(name) => {
+                    self.advance();
+                    name
+                }
+                _ => return Err(self.error("Expected identifier in import path".to_string())),
+            };
+            path.push(segment);
+        }
+
+        Ok(Stmt::Import { path })
+    }
+
+    fn parse_try_catch(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'try'
+        let try_block = self.parse_block()?;
+
+        self.expect(&TokenKind::Catch)?;
+        let catch_var = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected variable name after 'catch'".to_string())),
+        };
+        let catch_block = self.parse_block()?;
+
+        Ok(Stmt::TryCatch {
+            try_block,
+            catch_var,
+            catch_block,
+        })
+    }
+
+    fn parse_test(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'test'
+
+        let name = match self.peek().clone() {
+            TokenKind::StringLiteral(s) => {
+                self.advance();
+                s
+            }
+            _ => return Err(self.error("Expected test name string after 'test'".to_string())),
+        };
+
+        let body = self.parse_block()?;
+        Ok(Stmt::TestFn { name, body })
+    }
+
+    // -- Closures, lists, string interpolation, concurrency --
+
+    fn parse_closure(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume '|'
+
+        let mut params = Vec::new();
+        if !self.at(&TokenKind::Pipe) {
+            loop {
+                let name = match self.peek().clone() {
+                    TokenKind::Identifier(name) => {
+                        self.advance();
+                        name
+                    }
+                    _ => return Err(self.error("Expected parameter name in closure".to_string())),
+                };
+                let type_ann = if self.at(&TokenKind::Colon) {
+                    self.advance();
+                    Some(self.parse_type()?)
+                } else {
+                    None
+                };
+                params.push(Param { name, type_ann });
+                if !self.at(&TokenKind::Comma) {
+                    break;
+                }
+                self.advance();
+            }
+        }
+        self.expect(&TokenKind::Pipe)?;
+
+        let body = if self.at(&TokenKind::LBrace) {
+            self.parse_block()?
+        } else {
+            let expr = self.parse_expr(0)?;
+            vec![Stmt::Expression(expr)]
+        };
+
+        Ok(Expr::Closure { params, body })
+    }
+
+    fn parse_list_literal(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume '['
+
+        let mut elements = Vec::new();
+        if !self.at(&TokenKind::RBracket) {
+            elements.push(self.parse_expr(0)?);
+            while self.at(&TokenKind::Comma) {
+                self.advance();
+                if self.at(&TokenKind::RBracket) {
+                    break; // trailing comma
+                }
+                elements.push(self.parse_expr(0)?);
+            }
+        }
+
+        self.expect(&TokenKind::RBracket)?;
+        Ok(Expr::ListLiteral(elements))
+    }
+
+    fn parse_string_interpolation(&mut self, first_literal: String) -> Result<Expr, ParseError> {
+        let mut parts = Vec::new();
+
+        if !first_literal.is_empty() {
+            parts.push(StringPart::Literal(first_literal));
+        }
+
+        while self.at(&TokenKind::InterpolationStart) {
+            self.advance(); // consume InterpolationStart
+            let expr = self.parse_expr(0)?;
+            self.expect(&TokenKind::InterpolationEnd)?;
+            parts.push(StringPart::Expr(expr));
+
+            // Check for trailing string literal
+            if let TokenKind::StringLiteral(s) = self.peek().clone() {
+                self.advance();
+                parts.push(StringPart::Literal(s));
+            }
+        }
+
+        Ok(Expr::StringInterpolation { parts })
+    }
+
+    fn parse_spawn(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume 'spawn'
+        let expr = self.parse_expr(0)?;
+        Ok(Expr::Spawn(Box::new(expr)))
+    }
+
+    fn parse_parallel(&mut self) -> Result<Expr, ParseError> {
+        self.advance(); // consume 'parallel'
+        let collection = self.parse_expr(0)?;
+        // The closure |param| { body } follows as a separate expression
+        let closure = self.parse_closure()?;
+        Ok(Expr::Parallel {
+            collection: Box::new(collection),
+            param: match &closure {
+                Expr::Closure { params, .. } => params[0].name.clone(),
+                _ => unreachable!(),
+            },
+            body: Box::new(closure),
+        })
     }
 
     // -- Type definitions --

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,9 +1,9 @@
-#![allow(dead_code)]
-
 pub mod ast;
 
 use crate::lexer::token::{Span, Token, TokenKind};
 use ast::*;
+
+const MAX_DEPTH: usize = 128;
 
 #[derive(Debug, Clone)]
 pub struct ParseError {
@@ -21,10 +21,21 @@ impl std::fmt::Display for ParseError {
     }
 }
 
+/// Tracks whether we're inside a `??` or `||`/`&&` chain,
+/// so we can reject mixing them without explicit parentheses.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ExprContext {
+    Normal,
+    Coalescing,
+    Logical,
+}
+
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
     errors: Vec<ParseError>,
+    depth: usize,
+    expr_context: ExprContext,
 }
 
 impl Parser {
@@ -33,6 +44,8 @@ impl Parser {
             tokens,
             pos: 0,
             errors: Vec::new(),
+            depth: 0,
+            expr_context: ExprContext::Normal,
         }
     }
 
@@ -45,7 +58,12 @@ impl Parser {
                 Ok(stmt) => stmts.push(stmt),
                 Err(e) => {
                     self.errors.push(e);
+                    let before = self.pos;
                     self.synchronize();
+                    // Fix #3: prevent infinite loop if synchronize didn't advance
+                    if self.pos == before {
+                        self.advance();
+                    }
                 }
             }
             self.skip_newlines();
@@ -61,6 +79,8 @@ impl Parser {
     // -- Statement parsing --
 
     fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
+
         // Collect decorators before the statement
         let decorators = if self.at(&TokenKind::At) {
             self.parse_decorators()?
@@ -68,10 +88,15 @@ impl Parser {
             vec![]
         };
 
+        // Fix #4: error if decorators precede a non-function statement
+        if !decorators.is_empty() && !matches!(self.peek(), TokenKind::Fn) {
+            return Err(self.error("Decorators are only valid on function definitions".to_string()));
+        }
+
         match self.peek() {
             TokenKind::Let => self.parse_let(),
             TokenKind::Return => self.parse_return(),
-            TokenKind::Fn => self.parse_fn(decorators),
+            TokenKind::Fn => self.parse_fn(decorators, start),
             TokenKind::For => self.parse_for(),
             TokenKind::While => self.parse_while(),
             TokenKind::Struct => self.parse_struct(),
@@ -82,12 +107,14 @@ impl Parser {
             TokenKind::Test => self.parse_test(),
             _ => {
                 let expr = self.parse_expr(0)?;
-                Ok(Stmt::Expression(expr))
+                let span = expr.span.clone();
+                Ok(Stmt::new(StmtKind::Expression(expr), span))
             }
         }
     }
 
     fn parse_let(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'let'
 
         let mutable = if self.at(&TokenKind::Mut) {
@@ -97,13 +124,7 @@ impl Parser {
             false
         };
 
-        let name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected variable name after 'let'".to_string())),
-        };
+        let name = self.expect_identifier("Expected variable name after 'let'")?;
 
         let type_ann = if self.at(&TokenKind::Colon) {
             self.advance();
@@ -115,15 +136,19 @@ impl Parser {
         self.expect(&TokenKind::Assign)?;
         let value = self.parse_expr(0)?;
 
-        Ok(Stmt::Let {
-            name,
-            mutable,
-            type_ann,
-            value,
-        })
+        Ok(Stmt::new(
+            StmtKind::Let {
+                name,
+                mutable,
+                type_ann,
+                value,
+            },
+            self.span_from(start),
+        ))
     }
 
     fn parse_return(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'return'
 
         // return with no value: next token is newline, }, or EOF
@@ -131,24 +156,20 @@ impl Parser {
             self.peek(),
             TokenKind::Newline | TokenKind::RBrace | TokenKind::EOF
         ) {
-            return Ok(Stmt::Return(None));
+            return Ok(Stmt::new(StmtKind::Return(None), self.span_from(start)));
         }
 
         let expr = self.parse_expr(0)?;
-        Ok(Stmt::Return(Some(expr)))
+        Ok(Stmt::new(
+            StmtKind::Return(Some(expr)),
+            self.span_from(start),
+        ))
     }
 
-    fn parse_fn(&mut self, decorators: Vec<Decorator>) -> Result<Stmt, ParseError> {
+    fn parse_fn(&mut self, decorators: Vec<Decorator>, start: usize) -> Result<Stmt, ParseError> {
         self.advance(); // consume 'fn'
 
-        let name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected function name after 'fn'".to_string())),
-        };
-
+        let name = self.expect_identifier("Expected function name after 'fn'")?;
         let params = self.parse_params()?;
 
         let return_type = if self.at(&TokenKind::Arrow) {
@@ -160,13 +181,16 @@ impl Parser {
 
         let body = self.parse_block()?;
 
-        Ok(Stmt::FnDef {
-            name,
-            params,
-            return_type,
-            body,
-            decorators,
-        })
+        Ok(Stmt::new(
+            StmtKind::FnDef {
+                name,
+                params,
+                return_type,
+                body,
+                decorators,
+            },
+            self.span_from(start),
+        ))
     }
 
     fn parse_params(&mut self) -> Result<Vec<Param>, ParseError> {
@@ -186,13 +210,7 @@ impl Parser {
     }
 
     fn parse_param(&mut self) -> Result<Param, ParseError> {
-        let name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected parameter name".to_string())),
-        };
+        let name = self.expect_identifier("Expected parameter name")?;
 
         let type_ann = if self.at(&TokenKind::Colon) {
             self.advance();
@@ -219,6 +237,11 @@ impl Parser {
     }
 
     // -- Type parsing --
+    // Note (issue #8): parse_type_suffix greedily consumes `<` as generic
+    // opening. This works because types and expressions are parsed in separate
+    // contexts today. If we ever add type ascription in expressions (e.g.
+    // `x as List<i32>`), we'll need lookahead to disambiguate `<` as generic
+    // vs comparison.
 
     fn parse_type(&mut self) -> Result<Type, ParseError> {
         let ty = match self.peek().clone() {
@@ -240,7 +263,6 @@ impl Parser {
                 self.advance();
                 self.parse_type_suffix(name)?
             }
-            // Type keywords: i32, i64, f32, f64, str, bool
             TokenKind::I32 => {
                 self.advance();
                 self.parse_type_suffix("i32".to_string())?
@@ -302,6 +324,29 @@ impl Parser {
     // -- Pratt expression parsing --
 
     fn parse_expr(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        // Fix #2: depth limit to prevent stack overflow on deeply nested input
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            self.depth -= 1;
+            return Err(self.error("Expression nesting depth exceeded".to_string()));
+        }
+
+        // Fix #7: save/restore coalescing context across fresh expression boundaries
+        let saved_context = self.expr_context;
+        if min_bp == 0 {
+            self.expr_context = ExprContext::Normal;
+        }
+
+        let result = self.parse_expr_inner(min_bp);
+
+        self.expr_context = saved_context;
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_expr_inner(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        let start = self.pos;
+
         // Parse prefix (nud)
         let mut lhs = self.parse_prefix()?;
 
@@ -315,10 +360,13 @@ impl Parser {
                     break;
                 }
                 let args = self.parse_args()?;
-                lhs = Expr::FnCall {
-                    callee: Box::new(lhs),
-                    args,
-                };
+                lhs = Expr::new(
+                    ExprKind::FnCall {
+                        callee: Box::new(lhs),
+                        args,
+                    },
+                    self.span_from(start),
+                );
                 continue;
             }
 
@@ -330,10 +378,13 @@ impl Parser {
                 self.advance();
                 let index = self.parse_expr(0)?;
                 self.expect(&TokenKind::RBracket)?;
-                lhs = Expr::Index {
-                    object: Box::new(lhs),
-                    index: Box::new(index),
-                };
+                lhs = Expr::new(
+                    ExprKind::Index {
+                        object: Box::new(lhs),
+                        index: Box::new(index),
+                    },
+                    self.span_from(start),
+                );
                 continue;
             }
 
@@ -343,26 +394,26 @@ impl Parser {
                     break;
                 }
                 self.advance();
-                let field = match self.peek().clone() {
-                    TokenKind::Identifier(name) => {
-                        self.advance();
-                        name
-                    }
-                    _ => return Err(self.error("Expected field name after '.'".to_string())),
-                };
+                let field = self.expect_identifier("Expected field name after '.'")?;
                 // If followed by '(', it's a method call
                 if *self.peek() == TokenKind::LParen {
                     let args = self.parse_args()?;
-                    lhs = Expr::MethodCall {
-                        object: Box::new(lhs),
-                        method: field,
-                        args,
-                    };
+                    lhs = Expr::new(
+                        ExprKind::MethodCall {
+                            object: Box::new(lhs),
+                            method: field,
+                            args,
+                        },
+                        self.span_from(start),
+                    );
                 } else {
-                    lhs = Expr::FieldAccess {
-                        object: Box::new(lhs),
-                        field,
-                    };
+                    lhs = Expr::new(
+                        ExprKind::FieldAccess {
+                            object: Box::new(lhs),
+                            field,
+                        },
+                        self.span_from(start),
+                    );
                 }
                 continue;
             }
@@ -373,17 +424,14 @@ impl Parser {
                     break;
                 }
                 self.advance();
-                let field = match self.peek().clone() {
-                    TokenKind::Identifier(name) => {
-                        self.advance();
-                        name
-                    }
-                    _ => return Err(self.error("Expected field name after '?.'".to_string())),
-                };
-                lhs = Expr::SafeAccess {
-                    object: Box::new(lhs),
-                    field,
-                };
+                let field = self.expect_identifier("Expected field name after '?.'")?;
+                lhs = Expr::new(
+                    ExprKind::SafeAccess {
+                        object: Box::new(lhs),
+                        field,
+                    },
+                    self.span_from(start),
+                );
                 continue;
             }
 
@@ -392,16 +440,36 @@ impl Parser {
                 if l_bp < min_bp {
                     break;
                 }
+
+                // Fix #7: reject mixing ?? with || / &&
+                if op == TokenKind::DoubleQuestion {
+                    if self.expr_context == ExprContext::Logical {
+                        return Err(self
+                            .error("Cannot mix ?? with || or && without parentheses".to_string()));
+                    }
+                    self.expr_context = ExprContext::Coalescing;
+                }
+                if matches!(op, TokenKind::And | TokenKind::Or) {
+                    if self.expr_context == ExprContext::Coalescing {
+                        return Err(self
+                            .error("Cannot mix ?? with || or && without parentheses".to_string()));
+                    }
+                    self.expr_context = ExprContext::Logical;
+                }
+
                 self.advance();
 
                 let rhs = self.parse_expr(r_bp)?;
                 lhs = if op == TokenKind::DoubleQuestion {
-                    Expr::NullCoalesce {
-                        left: Box::new(lhs),
-                        right: Box::new(rhs),
-                    }
+                    Expr::new(
+                        ExprKind::NullCoalesce {
+                            left: Box::new(lhs),
+                            right: Box::new(rhs),
+                        },
+                        self.span_from(start),
+                    )
                 } else {
-                    self.make_binary(lhs, &op, rhs)
+                    Expr::new(self.make_binary(lhs, &op, rhs), self.span_from(start))
                 };
             } else {
                 break;
@@ -426,39 +494,46 @@ impl Parser {
     }
 
     fn parse_prefix(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         match self.peek().clone() {
             TokenKind::IntLiteral(n) => {
                 self.advance();
-                Ok(Expr::IntLiteral(n))
+                Ok(Expr::new(ExprKind::IntLiteral(n), self.span_from(start)))
             }
             TokenKind::FloatLiteral(n) => {
                 self.advance();
-                Ok(Expr::FloatLiteral(n))
+                Ok(Expr::new(ExprKind::FloatLiteral(n), self.span_from(start)))
             }
             TokenKind::StringLiteral(s) => {
                 self.advance();
                 // Check if this is the start of string interpolation
                 if self.at(&TokenKind::InterpolationStart) {
-                    self.parse_string_interpolation(s)
+                    self.parse_string_interpolation(s, start)
                 } else {
-                    Ok(Expr::StringLiteral(s))
+                    Ok(Expr::new(ExprKind::StringLiteral(s), self.span_from(start)))
                 }
             }
             TokenKind::InterpolationStart => {
                 // Interpolation at start of string (empty prefix)
-                self.parse_string_interpolation(String::new())
+                self.parse_string_interpolation(String::new(), start)
             }
             TokenKind::True => {
                 self.advance();
-                Ok(Expr::BoolLiteral(true))
+                Ok(Expr::new(
+                    ExprKind::BoolLiteral(true),
+                    self.span_from(start),
+                ))
             }
             TokenKind::False => {
                 self.advance();
-                Ok(Expr::BoolLiteral(false))
+                Ok(Expr::new(
+                    ExprKind::BoolLiteral(false),
+                    self.span_from(start),
+                ))
             }
             TokenKind::Identifier(name) => {
                 self.advance();
-                Ok(Expr::Identifier(name))
+                Ok(Expr::new(ExprKind::Identifier(name), self.span_from(start)))
             }
             TokenKind::LParen => {
                 self.advance();
@@ -470,19 +545,25 @@ impl Parser {
                 self.advance();
                 let bp = Self::prefix_binding_power(&TokenKind::Minus);
                 let expr = self.parse_expr(bp)?;
-                Ok(Expr::UnaryOp {
-                    op: UnOp::Neg,
-                    expr: Box::new(expr),
-                })
+                Ok(Expr::new(
+                    ExprKind::UnaryOp {
+                        op: UnOp::Neg,
+                        expr: Box::new(expr),
+                    },
+                    self.span_from(start),
+                ))
             }
             TokenKind::Not => {
                 self.advance();
                 let bp = Self::prefix_binding_power(&TokenKind::Not);
                 let expr = self.parse_expr(bp)?;
-                Ok(Expr::UnaryOp {
-                    op: UnOp::Not,
-                    expr: Box::new(expr),
-                })
+                Ok(Expr::new(
+                    ExprKind::UnaryOp {
+                        op: UnOp::Not,
+                        expr: Box::new(expr),
+                    },
+                    self.span_from(start),
+                ))
             }
             TokenKind::If => self.parse_if(),
             TokenKind::Match => self.parse_match(),
@@ -497,6 +578,7 @@ impl Parser {
     // -- Control flow --
 
     fn parse_if(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'if'
 
         let condition = self.parse_expr(0)?;
@@ -507,7 +589,8 @@ impl Parser {
             if self.at(&TokenKind::If) {
                 // else if -> the else block is a single expression statement containing another if
                 let nested_if = self.parse_if()?;
-                Some(vec![Stmt::Expression(nested_if)])
+                let span = nested_if.span.clone();
+                Some(vec![Stmt::new(StmtKind::Expression(nested_if), span)])
             } else {
                 Some(self.parse_block()?)
             }
@@ -515,14 +598,18 @@ impl Parser {
             None
         };
 
-        Ok(Expr::IfElse {
-            condition: Box::new(condition),
-            then_block,
-            else_block,
-        })
+        Ok(Expr::new(
+            ExprKind::IfElse {
+                condition: Box::new(condition),
+                then_block,
+                else_block,
+            },
+            self.span_from(start),
+        ))
     }
 
     fn parse_match(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'match'
 
         let matched = self.parse_expr(0)?;
@@ -544,37 +631,42 @@ impl Parser {
         }
 
         self.expect(&TokenKind::RBrace)?;
-        Ok(Expr::Match {
-            expr: Box::new(matched),
-            arms,
-        })
+        Ok(Expr::new(
+            ExprKind::Match {
+                expr: Box::new(matched),
+                arms,
+            },
+            self.span_from(start),
+        ))
     }
 
     fn parse_for(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'for'
 
-        let var = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected variable name after 'for'".to_string())),
-        };
+        let var = self.expect_identifier("Expected variable name after 'for'")?;
 
         self.expect(&TokenKind::In)?;
         let iter = self.parse_expr(0)?;
         let body = self.parse_block()?;
 
-        Ok(Stmt::ForLoop { var, iter, body })
+        Ok(Stmt::new(
+            StmtKind::ForLoop { var, iter, body },
+            self.span_from(start),
+        ))
     }
 
     fn parse_while(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'while'
 
         let condition = self.parse_expr(0)?;
         let body = self.parse_block()?;
 
-        Ok(Stmt::WhileLoop { condition, body })
+        Ok(Stmt::new(
+            StmtKind::WhileLoop { condition, body },
+            self.span_from(start),
+        ))
     }
 
     // -- Decorators, imports, try/catch, test --
@@ -584,30 +676,14 @@ impl Parser {
 
         while self.at(&TokenKind::At) {
             self.advance(); // consume '@'
-            let name = match self.peek().clone() {
-                TokenKind::Identifier(name) => {
-                    self.advance();
-                    name
-                }
-                _ => return Err(self.error("Expected decorator name after '@'".to_string())),
-            };
+            let name = self.expect_identifier("Expected decorator name after '@'")?;
 
             let args = if self.at(&TokenKind::LParen) {
                 self.advance();
                 let mut args = Vec::new();
                 if !self.at(&TokenKind::RParen) {
                     loop {
-                        let key = match self.peek().clone() {
-                            TokenKind::Identifier(k) => {
-                                self.advance();
-                                k
-                            }
-                            _ => {
-                                return Err(
-                                    self.error("Expected argument name in decorator".to_string())
-                                );
-                            }
-                        };
+                        let key = self.expect_identifier("Expected argument name in decorator")?;
                         self.expect(&TokenKind::Colon)?;
                         let value = self.parse_expr(0)?;
                         args.push((key, value));
@@ -631,55 +707,43 @@ impl Parser {
     }
 
     fn parse_import(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'import'
 
         let mut path = Vec::new();
-        let first = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected module path after 'import'".to_string())),
-        };
+        let first = self.expect_identifier("Expected module path after 'import'")?;
         path.push(first);
 
         while self.at(&TokenKind::Dot) {
             self.advance();
-            let segment = match self.peek().clone() {
-                TokenKind::Identifier(name) => {
-                    self.advance();
-                    name
-                }
-                _ => return Err(self.error("Expected identifier in import path".to_string())),
-            };
+            let segment = self.expect_identifier("Expected identifier in import path")?;
             path.push(segment);
         }
 
-        Ok(Stmt::Import { path })
+        Ok(Stmt::new(StmtKind::Import { path }, self.span_from(start)))
     }
 
     fn parse_try_catch(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'try'
         let try_block = self.parse_block()?;
 
         self.expect(&TokenKind::Catch)?;
-        let catch_var = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected variable name after 'catch'".to_string())),
-        };
+        let catch_var = self.expect_identifier("Expected variable name after 'catch'")?;
         let catch_block = self.parse_block()?;
 
-        Ok(Stmt::TryCatch {
-            try_block,
-            catch_var,
-            catch_block,
-        })
+        Ok(Stmt::new(
+            StmtKind::TryCatch {
+                try_block,
+                catch_var,
+                catch_block,
+            },
+            self.span_from(start),
+        ))
     }
 
     fn parse_test(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'test'
 
         let name = match self.peek().clone() {
@@ -691,24 +755,22 @@ impl Parser {
         };
 
         let body = self.parse_block()?;
-        Ok(Stmt::TestFn { name, body })
+        Ok(Stmt::new(
+            StmtKind::TestFn { name, body },
+            self.span_from(start),
+        ))
     }
 
     // -- Closures, lists, string interpolation, concurrency --
 
     fn parse_closure(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume '|'
 
         let mut params = Vec::new();
         if !self.at(&TokenKind::Pipe) {
             loop {
-                let name = match self.peek().clone() {
-                    TokenKind::Identifier(name) => {
-                        self.advance();
-                        name
-                    }
-                    _ => return Err(self.error("Expected parameter name in closure".to_string())),
-                };
+                let name = self.expect_identifier("Expected parameter name in closure")?;
                 let type_ann = if self.at(&TokenKind::Colon) {
                     self.advance();
                     Some(self.parse_type()?)
@@ -728,13 +790,18 @@ impl Parser {
             self.parse_block()?
         } else {
             let expr = self.parse_expr(0)?;
-            vec![Stmt::Expression(expr)]
+            let span = expr.span.clone();
+            vec![Stmt::new(StmtKind::Expression(expr), span)]
         };
 
-        Ok(Expr::Closure { params, body })
+        Ok(Expr::new(
+            ExprKind::Closure { params, body },
+            self.span_from(start),
+        ))
     }
 
     fn parse_list_literal(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume '['
 
         let mut elements = Vec::new();
@@ -750,10 +817,17 @@ impl Parser {
         }
 
         self.expect(&TokenKind::RBracket)?;
-        Ok(Expr::ListLiteral(elements))
+        Ok(Expr::new(
+            ExprKind::ListLiteral(elements),
+            self.span_from(start),
+        ))
     }
 
-    fn parse_string_interpolation(&mut self, first_literal: String) -> Result<Expr, ParseError> {
+    fn parse_string_interpolation(
+        &mut self,
+        first_literal: String,
+        start: usize,
+    ) -> Result<Expr, ParseError> {
         let mut parts = Vec::new();
 
         if !first_literal.is_empty() {
@@ -773,55 +847,64 @@ impl Parser {
             }
         }
 
-        Ok(Expr::StringInterpolation { parts })
+        Ok(Expr::new(
+            ExprKind::StringInterpolation { parts },
+            self.span_from(start),
+        ))
     }
 
     fn parse_spawn(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'spawn'
         let expr = self.parse_expr(0)?;
-        Ok(Expr::Spawn(Box::new(expr)))
+        Ok(Expr::new(
+            ExprKind::Spawn(Box::new(expr)),
+            self.span_from(start),
+        ))
     }
 
     fn parse_parallel(&mut self) -> Result<Expr, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'parallel'
         let collection = self.parse_expr(0)?;
-        // The closure |param| { body } follows as a separate expression
         let closure = self.parse_closure()?;
-        Ok(Expr::Parallel {
-            collection: Box::new(collection),
-            param: match &closure {
-                Expr::Closure { params, .. } => params[0].name.clone(),
-                _ => unreachable!(),
+
+        // Fix #5: validate closure has at least one parameter
+        let param = match &closure.kind {
+            ExprKind::Closure { params, .. } if !params.is_empty() => params[0].name.clone(),
+            ExprKind::Closure { .. } => {
+                return Err(self
+                    .error("Parallel requires a closure with at least one parameter".to_string()));
+            }
+            _ => {
+                return Err(self.error("Expected closure after parallel collection".to_string()));
+            }
+        };
+
+        Ok(Expr::new(
+            ExprKind::Parallel {
+                collection: Box::new(collection),
+                param,
+                body: Box::new(closure),
             },
-            body: Box::new(closure),
-        })
+            self.span_from(start),
+        ))
     }
 
     // -- Type definitions --
 
     fn parse_struct(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'struct'
 
-        let name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected struct name".to_string())),
-        };
+        let name = self.expect_identifier("Expected struct name")?;
 
         self.expect(&TokenKind::LBrace)?;
         self.skip_newlines();
 
         let mut fields = Vec::new();
         while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
-            let field_name = match self.peek().clone() {
-                TokenKind::Identifier(name) => {
-                    self.advance();
-                    name
-                }
-                _ => return Err(self.error("Expected field name".to_string())),
-            };
+            let field_name = self.expect_identifier("Expected field name")?;
             self.expect(&TokenKind::Colon)?;
             let type_ann = self.parse_type()?;
             fields.push(Field {
@@ -836,19 +919,17 @@ impl Parser {
         }
 
         self.expect(&TokenKind::RBrace)?;
-        Ok(Stmt::StructDef { name, fields })
+        Ok(Stmt::new(
+            StmtKind::StructDef { name, fields },
+            self.span_from(start),
+        ))
     }
 
     fn parse_trait(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'trait'
 
-        let name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected trait name".to_string())),
-        };
+        let name = self.expect_identifier("Expected trait name")?;
 
         self.expect(&TokenKind::LBrace)?;
         self.skip_newlines();
@@ -856,13 +937,7 @@ impl Parser {
         let mut methods = Vec::new();
         while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
             self.expect(&TokenKind::Fn)?;
-            let method_name = match self.peek().clone() {
-                TokenKind::Identifier(name) => {
-                    self.advance();
-                    name
-                }
-                _ => return Err(self.error("Expected method name".to_string())),
-            };
+            let method_name = self.expect_identifier("Expected method name")?;
 
             let params = self.parse_params()?;
 
@@ -882,30 +957,22 @@ impl Parser {
         }
 
         self.expect(&TokenKind::RBrace)?;
-        Ok(Stmt::TraitDef { name, methods })
+        Ok(Stmt::new(
+            StmtKind::TraitDef { name, methods },
+            self.span_from(start),
+        ))
     }
 
     fn parse_impl(&mut self) -> Result<Stmt, ParseError> {
+        let start = self.pos;
         self.advance(); // consume 'impl'
 
-        let first_name = match self.peek().clone() {
-            TokenKind::Identifier(name) => {
-                self.advance();
-                name
-            }
-            _ => return Err(self.error("Expected type name after 'impl'".to_string())),
-        };
+        let first_name = self.expect_identifier("Expected type name after 'impl'")?;
 
         // Check for "impl Trait for Type"
         let (trait_name, target) = if self.at(&TokenKind::For) {
             self.advance();
-            let target = match self.peek().clone() {
-                TokenKind::Identifier(name) => {
-                    self.advance();
-                    name
-                }
-                _ => return Err(self.error("Expected type name after 'for'".to_string())),
-            };
+            let target = self.expect_identifier("Expected type name after 'for'")?;
             (Some(first_name), target)
         } else {
             (None, first_name)
@@ -917,21 +984,27 @@ impl Parser {
         let mut methods = Vec::new();
         while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
             match self.peek() {
-                TokenKind::Fn => methods.push(self.parse_fn(vec![])?),
+                TokenKind::Fn => {
+                    let fn_start = self.pos;
+                    methods.push(self.parse_fn(vec![], fn_start)?);
+                }
                 _ => return Err(self.error("Expected 'fn' in impl block".to_string())),
             }
             self.skip_newlines();
         }
 
         self.expect(&TokenKind::RBrace)?;
-        Ok(Stmt::ImplBlock {
-            trait_name,
-            target,
-            methods,
-        })
+        Ok(Stmt::new(
+            StmtKind::ImplBlock {
+                trait_name,
+                target,
+                methods,
+            },
+            self.span_from(start),
+        ))
     }
 
-    fn make_binary(&self, left: Expr, op: &TokenKind, right: Expr) -> Expr {
+    fn make_binary(&self, left: Expr, op: &TokenKind, right: Expr) -> ExprKind {
         let bin_op = match op {
             TokenKind::Plus => BinOp::Add,
             TokenKind::Minus => BinOp::Sub,
@@ -949,7 +1022,7 @@ impl Parser {
             TokenKind::DotDot => BinOp::Range,
             _ => unreachable!("Not a binary operator: {:?}", op),
         };
-        Expr::BinaryOp {
+        ExprKind::BinaryOp {
             left: Box::new(left),
             op: bin_op,
             right: Box::new(right),
@@ -1042,6 +1115,19 @@ impl Parser {
         }
     }
 
+    /// Fix #6: centralized identifier extraction to reduce clone boilerplate.
+    /// Still clones the string from the token -- a string interner would
+    /// eliminate these allocations but isn't warranted yet.
+    fn expect_identifier(&mut self, msg: &str) -> Result<String, ParseError> {
+        match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                Ok(name)
+            }
+            _ => Err(self.error(msg.to_string())),
+        }
+    }
+
     fn skip_newlines(&mut self) {
         while self.at(&TokenKind::Newline) {
             self.advance();
@@ -1052,6 +1138,18 @@ impl Parser {
         ParseError {
             message,
             span: self.peek_token().span.clone(),
+        }
+    }
+
+    fn span_from(&self, start: usize) -> Span {
+        let start_span = &self.tokens[start].span;
+        let end_idx = if self.pos > 0 { self.pos - 1 } else { 0 };
+        let end_span = &self.tokens[end_idx].span;
+        Span {
+            start: start_span.start,
+            end: end_span.end,
+            line: start_span.line,
+            column: start_span.column,
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,6 +3,7 @@
 pub mod ast;
 
 use crate::lexer::token::{Span, Token, TokenKind};
+use ast::*;
 
 #[derive(Debug, Clone)]
 pub struct ParseError {
@@ -35,17 +36,172 @@ impl Parser {
         }
     }
 
-    pub fn parse(&mut self) -> Vec<ast::Stmt> {
-        let stmts = Vec::new();
+    pub fn parse(&mut self) -> Vec<Stmt> {
+        let mut stmts = Vec::new();
 
         self.skip_newlines();
-        // Statement parsing will be added in Task 2+
+        while !self.at(&TokenKind::EOF) {
+            match self.parse_statement() {
+                Ok(stmt) => stmts.push(stmt),
+                Err(e) => {
+                    self.errors.push(e);
+                    break;
+                }
+            }
+            self.skip_newlines();
+        }
 
         stmts
     }
 
     pub fn errors(&self) -> &[ParseError] {
         &self.errors
+    }
+
+    // -- Statement parsing --
+
+    fn parse_statement(&mut self) -> Result<Stmt, ParseError> {
+        let expr = self.parse_expr(0)?;
+        Ok(Stmt::Expression(expr))
+    }
+
+    // -- Pratt expression parsing --
+
+    fn parse_expr(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        // Parse prefix (nud)
+        let mut lhs = self.parse_prefix()?;
+
+        // Parse infix/postfix (led)
+        loop {
+            let op = self.peek().clone();
+
+            // Check for postfix operators (Task 3)
+            // ...
+
+            // Check for infix operators
+            if let Some((l_bp, r_bp)) = Self::infix_binding_power(&op) {
+                if l_bp < min_bp {
+                    break;
+                }
+                self.advance();
+
+                let rhs = self.parse_expr(r_bp)?;
+                lhs = if op == TokenKind::DoubleQuestion {
+                    Expr::NullCoalesce {
+                        left: Box::new(lhs),
+                        right: Box::new(rhs),
+                    }
+                } else {
+                    self.make_binary(lhs, &op, rhs)
+                };
+            } else {
+                break;
+            }
+        }
+
+        Ok(lhs)
+    }
+
+    fn parse_prefix(&mut self) -> Result<Expr, ParseError> {
+        match self.peek().clone() {
+            TokenKind::IntLiteral(n) => {
+                self.advance();
+                Ok(Expr::IntLiteral(n))
+            }
+            TokenKind::FloatLiteral(n) => {
+                self.advance();
+                Ok(Expr::FloatLiteral(n))
+            }
+            TokenKind::StringLiteral(s) => {
+                self.advance();
+                Ok(Expr::StringLiteral(s))
+            }
+            TokenKind::True => {
+                self.advance();
+                Ok(Expr::BoolLiteral(true))
+            }
+            TokenKind::False => {
+                self.advance();
+                Ok(Expr::BoolLiteral(false))
+            }
+            TokenKind::Identifier(name) => {
+                self.advance();
+                Ok(Expr::Identifier(name))
+            }
+            TokenKind::LParen => {
+                self.advance();
+                let expr = self.parse_expr(0)?;
+                self.expect(&TokenKind::RParen)?;
+                Ok(expr)
+            }
+            TokenKind::Minus => {
+                self.advance();
+                let bp = Self::prefix_binding_power(&TokenKind::Minus);
+                let expr = self.parse_expr(bp)?;
+                Ok(Expr::UnaryOp {
+                    op: UnOp::Neg,
+                    expr: Box::new(expr),
+                })
+            }
+            TokenKind::Not => {
+                self.advance();
+                let bp = Self::prefix_binding_power(&TokenKind::Not);
+                let expr = self.parse_expr(bp)?;
+                Ok(Expr::UnaryOp {
+                    op: UnOp::Not,
+                    expr: Box::new(expr),
+                })
+            }
+            _ => Err(self.error(format!("Expected expression, found {:?}", self.peek()))),
+        }
+    }
+
+    fn make_binary(&self, left: Expr, op: &TokenKind, right: Expr) -> Expr {
+        let bin_op = match op {
+            TokenKind::Plus => BinOp::Add,
+            TokenKind::Minus => BinOp::Sub,
+            TokenKind::Star => BinOp::Mul,
+            TokenKind::Slash => BinOp::Div,
+            TokenKind::Percent => BinOp::Mod,
+            TokenKind::Eq => BinOp::Eq,
+            TokenKind::NotEq => BinOp::NotEq,
+            TokenKind::Lt => BinOp::Lt,
+            TokenKind::Gt => BinOp::Gt,
+            TokenKind::LtEq => BinOp::LtEq,
+            TokenKind::GtEq => BinOp::GtEq,
+            TokenKind::And => BinOp::And,
+            TokenKind::Or => BinOp::Or,
+            _ => unreachable!("Not a binary operator: {:?}", op),
+        };
+        Expr::BinaryOp {
+            left: Box::new(left),
+            op: bin_op,
+            right: Box::new(right),
+        }
+    }
+
+    // Binding power for prefix (unary) operators
+    fn prefix_binding_power(op: &TokenKind) -> u8 {
+        match op {
+            TokenKind::Minus | TokenKind::Not => 13,
+            _ => 0,
+        }
+    }
+
+    // Binding power for infix (binary) operators: (left_bp, right_bp)
+    // Left-associative: right_bp = left_bp + 1
+    // Right-associative: right_bp = left_bp - 1
+    fn infix_binding_power(op: &TokenKind) -> Option<(u8, u8)> {
+        match op {
+            TokenKind::DoubleQuestion => Some((2, 1)), // right-assoc
+            TokenKind::Or => Some((3, 4)),
+            TokenKind::And => Some((5, 6)),
+            TokenKind::Eq | TokenKind::NotEq => Some((7, 8)),
+            TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq => Some((7, 8)),
+            TokenKind::Plus | TokenKind::Minus => Some((9, 10)),
+            TokenKind::Star | TokenKind::Slash | TokenKind::Percent => Some((11, 12)),
+            _ => None,
+        }
     }
 
     // -- Token cursor methods --

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -67,6 +67,9 @@ impl Parser {
             TokenKind::Fn => self.parse_fn(vec![]),
             TokenKind::For => self.parse_for(),
             TokenKind::While => self.parse_while(),
+            TokenKind::Struct => self.parse_struct(),
+            TokenKind::Trait => self.parse_trait(),
+            TokenKind::Impl => self.parse_impl(),
             _ => {
                 let expr = self.parse_expr(0)?;
                 Ok(Stmt::Expression(expr))
@@ -549,6 +552,140 @@ impl Parser {
         let body = self.parse_block()?;
 
         Ok(Stmt::WhileLoop { condition, body })
+    }
+
+    // -- Type definitions --
+
+    fn parse_struct(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'struct'
+
+        let name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected struct name".to_string())),
+        };
+
+        self.expect(&TokenKind::LBrace)?;
+        self.skip_newlines();
+
+        let mut fields = Vec::new();
+        while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
+            let field_name = match self.peek().clone() {
+                TokenKind::Identifier(name) => {
+                    self.advance();
+                    name
+                }
+                _ => return Err(self.error("Expected field name".to_string())),
+            };
+            self.expect(&TokenKind::Colon)?;
+            let type_ann = self.parse_type()?;
+            fields.push(Field {
+                name: field_name,
+                type_ann,
+            });
+
+            if self.at(&TokenKind::Comma) {
+                self.advance();
+            }
+            self.skip_newlines();
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Stmt::StructDef { name, fields })
+    }
+
+    fn parse_trait(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'trait'
+
+        let name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected trait name".to_string())),
+        };
+
+        self.expect(&TokenKind::LBrace)?;
+        self.skip_newlines();
+
+        let mut methods = Vec::new();
+        while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
+            self.expect(&TokenKind::Fn)?;
+            let method_name = match self.peek().clone() {
+                TokenKind::Identifier(name) => {
+                    self.advance();
+                    name
+                }
+                _ => return Err(self.error("Expected method name".to_string())),
+            };
+
+            let params = self.parse_params()?;
+
+            let return_type = if self.at(&TokenKind::Arrow) {
+                self.advance();
+                Some(self.parse_type()?)
+            } else {
+                None
+            };
+
+            methods.push(FnSignature {
+                name: method_name,
+                params,
+                return_type,
+            });
+            self.skip_newlines();
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Stmt::TraitDef { name, methods })
+    }
+
+    fn parse_impl(&mut self) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'impl'
+
+        let first_name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected type name after 'impl'".to_string())),
+        };
+
+        // Check for "impl Trait for Type"
+        let (trait_name, target) = if self.at(&TokenKind::For) {
+            self.advance();
+            let target = match self.peek().clone() {
+                TokenKind::Identifier(name) => {
+                    self.advance();
+                    name
+                }
+                _ => return Err(self.error("Expected type name after 'for'".to_string())),
+            };
+            (Some(first_name), target)
+        } else {
+            (None, first_name)
+        };
+
+        self.expect(&TokenKind::LBrace)?;
+        self.skip_newlines();
+
+        let mut methods = Vec::new();
+        while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
+            match self.peek() {
+                TokenKind::Fn => methods.push(self.parse_fn(vec![])?),
+                _ => return Err(self.error("Expected 'fn' in impl block".to_string())),
+            }
+            self.skip_newlines();
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Stmt::ImplBlock {
+            trait_name,
+            target,
+            methods,
+        })
     }
 
     fn make_binary(&self, left: Expr, op: &TokenKind, right: Expr) -> Expr {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -75,10 +75,85 @@ impl Parser {
         loop {
             let op = self.peek().clone();
 
-            // Check for postfix operators (Task 3)
-            // ...
+            // Postfix: function call
+            if op == TokenKind::LParen {
+                if 15 < min_bp {
+                    break;
+                }
+                let args = self.parse_args()?;
+                lhs = Expr::FnCall {
+                    callee: Box::new(lhs),
+                    args,
+                };
+                continue;
+            }
 
-            // Check for infix operators
+            // Postfix: index access
+            if op == TokenKind::LBracket {
+                if 15 < min_bp {
+                    break;
+                }
+                self.advance();
+                let index = self.parse_expr(0)?;
+                self.expect(&TokenKind::RBracket)?;
+                lhs = Expr::Index {
+                    object: Box::new(lhs),
+                    index: Box::new(index),
+                };
+                continue;
+            }
+
+            // Postfix: field access / method call
+            if op == TokenKind::Dot {
+                if 15 < min_bp {
+                    break;
+                }
+                self.advance();
+                let field = match self.peek().clone() {
+                    TokenKind::Identifier(name) => {
+                        self.advance();
+                        name
+                    }
+                    _ => return Err(self.error("Expected field name after '.'".to_string())),
+                };
+                // If followed by '(', it's a method call
+                if *self.peek() == TokenKind::LParen {
+                    let args = self.parse_args()?;
+                    lhs = Expr::MethodCall {
+                        object: Box::new(lhs),
+                        method: field,
+                        args,
+                    };
+                } else {
+                    lhs = Expr::FieldAccess {
+                        object: Box::new(lhs),
+                        field,
+                    };
+                }
+                continue;
+            }
+
+            // Postfix: safe access
+            if op == TokenKind::QuestionDot {
+                if 15 < min_bp {
+                    break;
+                }
+                self.advance();
+                let field = match self.peek().clone() {
+                    TokenKind::Identifier(name) => {
+                        self.advance();
+                        name
+                    }
+                    _ => return Err(self.error("Expected field name after '?.'".to_string())),
+                };
+                lhs = Expr::SafeAccess {
+                    object: Box::new(lhs),
+                    field,
+                };
+                continue;
+            }
+
+            // Infix: binary operators
             if let Some((l_bp, r_bp)) = Self::infix_binding_power(&op) {
                 if l_bp < min_bp {
                     break;
@@ -100,6 +175,20 @@ impl Parser {
         }
 
         Ok(lhs)
+    }
+
+    fn parse_args(&mut self) -> Result<Vec<Expr>, ParseError> {
+        self.expect(&TokenKind::LParen)?;
+        let mut args = Vec::new();
+        if !self.at(&TokenKind::RParen) {
+            args.push(self.parse_expr(0)?);
+            while self.at(&TokenKind::Comma) {
+                self.advance();
+                args.push(self.parse_expr(0)?);
+            }
+        }
+        self.expect(&TokenKind::RParen)?;
+        Ok(args)
     }
 
     fn parse_prefix(&mut self) -> Result<Expr, ParseError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -64,6 +64,7 @@ impl Parser {
         match self.peek() {
             TokenKind::Let => self.parse_let(),
             TokenKind::Return => self.parse_return(),
+            TokenKind::Fn => self.parse_fn(vec![]),
             _ => {
                 let expr = self.parse_expr(0)?;
                 Ok(Stmt::Expression(expr))
@@ -120,6 +121,86 @@ impl Parser {
 
         let expr = self.parse_expr(0)?;
         Ok(Stmt::Return(Some(expr)))
+    }
+
+    fn parse_fn(&mut self, decorators: Vec<Decorator>) -> Result<Stmt, ParseError> {
+        self.advance(); // consume 'fn'
+
+        let name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected function name after 'fn'".to_string())),
+        };
+
+        let params = self.parse_params()?;
+
+        let return_type = if self.at(&TokenKind::Arrow) {
+            self.advance();
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+
+        let body = self.parse_block()?;
+
+        Ok(Stmt::FnDef {
+            name,
+            params,
+            return_type,
+            body,
+            decorators,
+        })
+    }
+
+    fn parse_params(&mut self) -> Result<Vec<Param>, ParseError> {
+        self.expect(&TokenKind::LParen)?;
+        let mut params = Vec::new();
+
+        if !self.at(&TokenKind::RParen) {
+            params.push(self.parse_param()?);
+            while self.at(&TokenKind::Comma) {
+                self.advance();
+                params.push(self.parse_param()?);
+            }
+        }
+
+        self.expect(&TokenKind::RParen)?;
+        Ok(params)
+    }
+
+    fn parse_param(&mut self) -> Result<Param, ParseError> {
+        let name = match self.peek().clone() {
+            TokenKind::Identifier(name) => {
+                self.advance();
+                name
+            }
+            _ => return Err(self.error("Expected parameter name".to_string())),
+        };
+
+        let type_ann = if self.at(&TokenKind::Colon) {
+            self.advance();
+            Some(self.parse_type()?)
+        } else {
+            None
+        };
+
+        Ok(Param { name, type_ann })
+    }
+
+    fn parse_block(&mut self) -> Result<Vec<Stmt>, ParseError> {
+        self.expect(&TokenKind::LBrace)?;
+        let mut stmts = Vec::new();
+
+        self.skip_newlines();
+        while !self.at(&TokenKind::RBrace) && !self.at(&TokenKind::EOF) {
+            stmts.push(self.parse_statement()?);
+            self.skip_newlines();
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(stmts)
     }
 
     // -- Type parsing --

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -13,15 +13,15 @@ fn version_prints_sage() {
 }
 
 #[test]
-fn build_lexes_hello_sg() {
+fn build_parses_hello_sg() {
     let output = Command::new(env!("CARGO_BIN_EXE_sage"))
         .args(["build", "examples/hello.sg"])
         .output()
         .expect("failed to run sage");
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Lexed"));
-    assert!(stdout.contains("tokens"));
+    assert!(stdout.contains("Parsed"));
+    assert!(stdout.contains("statements"));
 }
 
 #[test]

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1154,3 +1154,42 @@ fn parse_parallel() {
         other => panic!("Expected Parallel, got {:?}", other),
     }
 }
+
+// -- Task 9: Error recovery --
+
+#[test]
+fn parse_error_unexpected_token() {
+    let (_, errors) = parse("let = 42");
+    assert!(!errors.is_empty());
+    assert!(errors[0].message.contains("Expected variable name"));
+}
+
+#[test]
+fn parse_error_missing_rbrace() {
+    let (_, errors) = parse("fn main() { let x = 1");
+    assert!(!errors.is_empty());
+}
+
+#[test]
+fn parse_error_recovery_continues() {
+    // First statement has an error, but second should still parse
+    let (stmts, errors) = parse("let = 42\nlet y = 10");
+    assert!(!errors.is_empty());
+    // After recovery, the second let should parse
+    assert!(
+        stmts
+            .iter()
+            .any(|s| matches!(s, Stmt::Let { name, .. } if name == "y")),
+        "Should recover and parse second let statement"
+    );
+}
+
+#[test]
+fn parse_multiple_errors() {
+    let (_, errors) = parse("let = 1\nlet = 2");
+    assert!(
+        errors.len() >= 2,
+        "Should report multiple errors, got {}",
+        errors.len()
+    );
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -601,3 +601,102 @@ fn parse_multi_generic_type() {
         other => panic!("Expected Let, got {:?}", other),
     }
 }
+
+// -- Task 5: Function definitions and blocks --
+
+#[test]
+fn parse_hello_world() {
+    let stmts = parse_ok("fn main() {\n    println(\"Hello, Sage!\")\n}");
+    assert_eq!(
+        stmts[0],
+        Stmt::FnDef {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            body: vec![Stmt::Expression(Expr::FnCall {
+                callee: Box::new(Expr::Identifier("println".to_string())),
+                args: vec![Expr::StringLiteral("Hello, Sage!".to_string())],
+            })],
+            decorators: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_fn_with_params_and_return() {
+    let stmts = parse_ok("fn add(a: i32, b: i32) -> i32 {\n    return a + b\n}");
+    assert_eq!(
+        stmts[0],
+        Stmt::FnDef {
+            name: "add".to_string(),
+            params: vec![
+                Param {
+                    name: "a".to_string(),
+                    type_ann: Some(Type::Simple("i32".to_string())),
+                },
+                Param {
+                    name: "b".to_string(),
+                    type_ann: Some(Type::Simple("i32".to_string())),
+                },
+            ],
+            return_type: Some(Type::Simple("i32".to_string())),
+            body: vec![Stmt::Return(Some(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("a".to_string())),
+                op: BinOp::Add,
+                right: Box::new(Expr::Identifier("b".to_string())),
+            }))],
+            decorators: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_fn_no_return_type() {
+    let stmts = parse_ok("fn greet(name: str) {\n    println(name)\n}");
+    match &stmts[0] {
+        Stmt::FnDef {
+            name,
+            params,
+            return_type,
+            ..
+        } => {
+            assert_eq!(name, "greet");
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "name");
+            assert!(return_type.is_none());
+        }
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_fn_multiple_statements() {
+    let stmts = parse_ok("fn calc() -> i32 {\n    let x = 1\n    let y = 2\n    return x + y\n}");
+    match &stmts[0] {
+        Stmt::FnDef { body, .. } => {
+            assert_eq!(body.len(), 3);
+            assert!(matches!(&body[0], Stmt::Let { name, .. } if name == "x"));
+            assert!(matches!(&body[1], Stmt::Let { name, .. } if name == "y"));
+            assert!(matches!(&body[2], Stmt::Return(Some(_))));
+        }
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_fn_empty_body() {
+    let stmts = parse_ok("fn noop() {}");
+    match &stmts[0] {
+        Stmt::FnDef { body, .. } => assert!(body.is_empty()),
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_multiple_top_level_fns() {
+    let src = "fn foo() {\n    1\n}\nfn bar() {\n    2\n}";
+    let stmts = parse_ok(src);
+    assert_eq!(stmts.len(), 2);
+    assert!(matches!(&stmts[0], Stmt::FnDef { name, .. } if name == "foo"));
+    assert!(matches!(&stmts[1], Stmt::FnDef { name, .. } if name == "bar"));
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -831,3 +831,119 @@ fn parse_match_with_commas() {
         other => panic!("Expected Match, got {:?}", other),
     }
 }
+
+// -- Task 7: Struct, trait, impl --
+
+#[test]
+fn parse_struct_def() {
+    let stmts = parse_ok("struct User {\n    name: str\n    age: i32\n}");
+    assert_eq!(
+        stmts[0],
+        Stmt::StructDef {
+            name: "User".to_string(),
+            fields: vec![
+                Field {
+                    name: "name".to_string(),
+                    type_ann: Type::Simple("str".to_string()),
+                },
+                Field {
+                    name: "age".to_string(),
+                    type_ann: Type::Simple("i32".to_string()),
+                },
+            ],
+        }
+    );
+}
+
+#[test]
+fn parse_struct_comma_separated() {
+    let stmts = parse_ok("struct Point { x: f64, y: f64 }");
+    match &stmts[0] {
+        Stmt::StructDef { name, fields } => {
+            assert_eq!(name, "Point");
+            assert_eq!(fields.len(), 2);
+        }
+        other => panic!("Expected StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_struct_empty() {
+    let stmts = parse_ok("struct Empty {}");
+    assert_eq!(
+        stmts[0],
+        Stmt::StructDef {
+            name: "Empty".to_string(),
+            fields: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_trait_def() {
+    let stmts = parse_ok("trait Greetable {\n    fn greet(self) -> str\n}");
+    assert_eq!(
+        stmts[0],
+        Stmt::TraitDef {
+            name: "Greetable".to_string(),
+            methods: vec![FnSignature {
+                name: "greet".to_string(),
+                params: vec![Param {
+                    name: "self".to_string(),
+                    type_ann: None,
+                }],
+                return_type: Some(Type::Simple("str".to_string())),
+            }],
+        }
+    );
+}
+
+#[test]
+fn parse_trait_multiple_methods() {
+    let stmts = parse_ok("trait Animal {\n    fn name(self) -> str\n    fn speak(self) -> str\n}");
+    match &stmts[0] {
+        Stmt::TraitDef { methods, .. } => {
+            assert_eq!(methods.len(), 2);
+            assert_eq!(methods[0].name, "name");
+            assert_eq!(methods[1].name, "speak");
+        }
+        other => panic!("Expected TraitDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_impl_block() {
+    let stmts = parse_ok("impl User {\n    fn new(name: str) -> User {\n        name\n    }\n}");
+    match &stmts[0] {
+        Stmt::ImplBlock {
+            trait_name,
+            target,
+            methods,
+        } => {
+            assert!(trait_name.is_none());
+            assert_eq!(target, "User");
+            assert_eq!(methods.len(), 1);
+            assert!(matches!(&methods[0], Stmt::FnDef { name, .. } if name == "new"));
+        }
+        other => panic!("Expected ImplBlock, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_impl_trait_for_type() {
+    let stmts = parse_ok(
+        "impl Greetable for User {\n    fn greet(self) -> str {\n        self.name\n    }\n}",
+    );
+    match &stmts[0] {
+        Stmt::ImplBlock {
+            trait_name,
+            target,
+            methods,
+        } => {
+            assert_eq!(*trait_name, Some("Greetable".to_string()));
+            assert_eq!(target, "User");
+            assert_eq!(methods.len(), 1);
+        }
+        other => panic!("Expected ImplBlock, got {:?}", other),
+    }
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -25,10 +25,24 @@ fn parse_ok(source: &str) -> Vec<Stmt> {
 fn parse_single_expr(source: &str) -> Expr {
     let stmts = parse_ok(source);
     assert_eq!(stmts.len(), 1, "Expected 1 statement, got {}", stmts.len());
-    match stmts.into_iter().next().unwrap() {
-        Stmt::Expression(expr) => expr,
+    match stmts.into_iter().next().unwrap().kind {
+        StmtKind::Expression(expr) => expr,
         other => panic!("Expected expression statement, got {:?}", other),
     }
+}
+
+// Helpers: wrap ExprKind/StmtKind into Expr/Stmt with dummy spans.
+// PartialEq on Expr/Stmt ignores span, so these compare correctly.
+fn e(kind: ExprKind) -> Expr {
+    Expr::dummy(kind)
+}
+
+fn be(kind: ExprKind) -> Box<Expr> {
+    Box::new(e(kind))
+}
+
+fn s(kind: StmtKind) -> Stmt {
+    Stmt::dummy(kind)
 }
 
 #[test]
@@ -47,37 +61,37 @@ fn parser_handles_empty_source() {
 #[test]
 fn parse_integer_literal() {
     let expr = parse_single_expr("42");
-    assert_eq!(expr, Expr::IntLiteral(42));
+    assert_eq!(expr, e(ExprKind::IntLiteral(42)));
 }
 
 #[test]
 fn parse_float_literal() {
     let expr = parse_single_expr("3.14");
-    assert_eq!(expr, Expr::FloatLiteral(3.14));
+    assert_eq!(expr, e(ExprKind::FloatLiteral(3.14)));
 }
 
 #[test]
 fn parse_string_literal() {
     let expr = parse_single_expr("\"hello\"");
-    assert_eq!(expr, Expr::StringLiteral("hello".to_string()));
+    assert_eq!(expr, e(ExprKind::StringLiteral("hello".to_string())));
 }
 
 #[test]
 fn parse_bool_true() {
     let expr = parse_single_expr("true");
-    assert_eq!(expr, Expr::BoolLiteral(true));
+    assert_eq!(expr, e(ExprKind::BoolLiteral(true)));
 }
 
 #[test]
 fn parse_bool_false() {
     let expr = parse_single_expr("false");
-    assert_eq!(expr, Expr::BoolLiteral(false));
+    assert_eq!(expr, e(ExprKind::BoolLiteral(false)));
 }
 
 #[test]
 fn parse_identifier() {
     let expr = parse_single_expr("foo");
-    assert_eq!(expr, Expr::Identifier("foo".to_string()));
+    assert_eq!(expr, e(ExprKind::Identifier("foo".to_string())));
 }
 
 #[test]
@@ -85,11 +99,11 @@ fn parse_binary_add() {
     let expr = parse_single_expr("1 + 2");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::IntLiteral(1)),
+        e(ExprKind::BinaryOp {
+            left: be(ExprKind::IntLiteral(1)),
             op: BinOp::Add,
-            right: Box::new(Expr::IntLiteral(2)),
-        }
+            right: be(ExprKind::IntLiteral(2)),
+        })
     );
 }
 
@@ -99,15 +113,15 @@ fn parse_precedence_mul_over_add() {
     let expr = parse_single_expr("1 + 2 * 3");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::IntLiteral(1)),
+        e(ExprKind::BinaryOp {
+            left: be(ExprKind::IntLiteral(1)),
             op: BinOp::Add,
-            right: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::IntLiteral(2)),
+            right: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::IntLiteral(2)),
                 op: BinOp::Mul,
-                right: Box::new(Expr::IntLiteral(3)),
-            }),
-        }
+                right: be(ExprKind::IntLiteral(3)),
+            })),
+        })
     );
 }
 
@@ -117,15 +131,15 @@ fn parse_precedence_left_associative() {
     let expr = parse_single_expr("1 - 2 - 3");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::IntLiteral(1)),
+        e(ExprKind::BinaryOp {
+            left: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::IntLiteral(1)),
                 op: BinOp::Sub,
-                right: Box::new(Expr::IntLiteral(2)),
-            }),
+                right: be(ExprKind::IntLiteral(2)),
+            })),
             op: BinOp::Sub,
-            right: Box::new(Expr::IntLiteral(3)),
-        }
+            right: be(ExprKind::IntLiteral(3)),
+        })
     );
 }
 
@@ -135,15 +149,15 @@ fn parse_grouped_expression() {
     let expr = parse_single_expr("(1 + 2) * 3");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::IntLiteral(1)),
+        e(ExprKind::BinaryOp {
+            left: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::IntLiteral(1)),
                 op: BinOp::Add,
-                right: Box::new(Expr::IntLiteral(2)),
-            }),
+                right: be(ExprKind::IntLiteral(2)),
+            })),
             op: BinOp::Mul,
-            right: Box::new(Expr::IntLiteral(3)),
-        }
+            right: be(ExprKind::IntLiteral(3)),
+        })
     );
 }
 
@@ -152,10 +166,10 @@ fn parse_unary_neg() {
     let expr = parse_single_expr("-x");
     assert_eq!(
         expr,
-        Expr::UnaryOp {
+        e(ExprKind::UnaryOp {
             op: UnOp::Neg,
-            expr: Box::new(Expr::Identifier("x".to_string())),
-        }
+            expr: be(ExprKind::Identifier("x".to_string())),
+        })
     );
 }
 
@@ -164,10 +178,10 @@ fn parse_unary_not() {
     let expr = parse_single_expr("!flag");
     assert_eq!(
         expr,
-        Expr::UnaryOp {
+        e(ExprKind::UnaryOp {
             op: UnOp::Not,
-            expr: Box::new(Expr::Identifier("flag".to_string())),
-        }
+            expr: be(ExprKind::Identifier("flag".to_string())),
+        })
     );
 }
 
@@ -176,11 +190,11 @@ fn parse_comparison() {
     let expr = parse_single_expr("a > b");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::Identifier("a".to_string())),
+        e(ExprKind::BinaryOp {
+            left: be(ExprKind::Identifier("a".to_string())),
             op: BinOp::Gt,
-            right: Box::new(Expr::Identifier("b".to_string())),
-        }
+            right: be(ExprKind::Identifier("b".to_string())),
+        })
     );
 }
 
@@ -190,15 +204,15 @@ fn parse_logical_and_or() {
     let expr = parse_single_expr("a && b || c");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("a".to_string())),
+        e(ExprKind::BinaryOp {
+            left: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::Identifier("a".to_string())),
                 op: BinOp::And,
-                right: Box::new(Expr::Identifier("b".to_string())),
-            }),
+                right: be(ExprKind::Identifier("b".to_string())),
+            })),
             op: BinOp::Or,
-            right: Box::new(Expr::Identifier("c".to_string())),
-        }
+            right: be(ExprKind::Identifier("c".to_string())),
+        })
     );
 }
 
@@ -221,11 +235,11 @@ fn parse_all_binary_ops() {
         ("a || b", BinOp::Or),
     ] {
         let expr = parse_single_expr(src);
-        match expr {
-            Expr::BinaryOp { op: parsed_op, .. } => {
+        match expr.kind {
+            ExprKind::BinaryOp { op: parsed_op, .. } => {
                 assert_eq!(parsed_op, op, "Failed for: {}", src)
             }
-            other => panic!("Expected BinaryOp for '{}', got {:?}", src, other),
+            ref other => panic!("Expected BinaryOp for '{}', got {:?}", src, other),
         }
     }
 }
@@ -236,23 +250,23 @@ fn parse_complex_precedence() {
     let expr = parse_single_expr("1 + 2 * 3 - 4 / 2");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::IntLiteral(1)),
+        e(ExprKind::BinaryOp {
+            left: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::IntLiteral(1)),
                 op: BinOp::Add,
-                right: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::IntLiteral(2)),
+                right: Box::new(e(ExprKind::BinaryOp {
+                    left: be(ExprKind::IntLiteral(2)),
                     op: BinOp::Mul,
-                    right: Box::new(Expr::IntLiteral(3)),
-                }),
-            }),
+                    right: be(ExprKind::IntLiteral(3)),
+                })),
+            })),
             op: BinOp::Sub,
-            right: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::IntLiteral(4)),
+            right: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::IntLiteral(4)),
                 op: BinOp::Div,
-                right: Box::new(Expr::IntLiteral(2)),
-            }),
-        }
+                right: be(ExprKind::IntLiteral(2)),
+            })),
+        })
     );
 }
 
@@ -262,14 +276,14 @@ fn parse_unary_in_binary() {
     let expr = parse_single_expr("-a + b");
     assert_eq!(
         expr,
-        Expr::BinaryOp {
-            left: Box::new(Expr::UnaryOp {
+        e(ExprKind::BinaryOp {
+            left: Box::new(e(ExprKind::UnaryOp {
                 op: UnOp::Neg,
-                expr: Box::new(Expr::Identifier("a".to_string())),
-            }),
+                expr: be(ExprKind::Identifier("a".to_string())),
+            })),
             op: BinOp::Add,
-            right: Box::new(Expr::Identifier("b".to_string())),
-        }
+            right: be(ExprKind::Identifier("b".to_string())),
+        })
     );
 }
 
@@ -280,10 +294,10 @@ fn parse_function_call_no_args() {
     let expr = parse_single_expr("foo()");
     assert_eq!(
         expr,
-        Expr::FnCall {
-            callee: Box::new(Expr::Identifier("foo".to_string())),
+        e(ExprKind::FnCall {
+            callee: be(ExprKind::Identifier("foo".to_string())),
             args: vec![],
-        }
+        })
     );
 }
 
@@ -292,10 +306,10 @@ fn parse_function_call_one_arg() {
     let expr = parse_single_expr("println(\"hello\")");
     assert_eq!(
         expr,
-        Expr::FnCall {
-            callee: Box::new(Expr::Identifier("println".to_string())),
-            args: vec![Expr::StringLiteral("hello".to_string())],
-        }
+        e(ExprKind::FnCall {
+            callee: be(ExprKind::Identifier("println".to_string())),
+            args: vec![e(ExprKind::StringLiteral("hello".to_string()))],
+        })
     );
 }
 
@@ -304,10 +318,10 @@ fn parse_function_call_multiple_args() {
     let expr = parse_single_expr("add(1, 2)");
     assert_eq!(
         expr,
-        Expr::FnCall {
-            callee: Box::new(Expr::Identifier("add".to_string())),
-            args: vec![Expr::IntLiteral(1), Expr::IntLiteral(2)],
-        }
+        e(ExprKind::FnCall {
+            callee: be(ExprKind::Identifier("add".to_string())),
+            args: vec![e(ExprKind::IntLiteral(1)), e(ExprKind::IntLiteral(2))],
+        })
     );
 }
 
@@ -316,26 +330,25 @@ fn parse_field_access() {
     let expr = parse_single_expr("user.name");
     assert_eq!(
         expr,
-        Expr::FieldAccess {
-            object: Box::new(Expr::Identifier("user".to_string())),
+        e(ExprKind::FieldAccess {
+            object: be(ExprKind::Identifier("user".to_string())),
             field: "name".to_string(),
-        }
+        })
     );
 }
 
 #[test]
 fn parse_chained_field_access() {
-    // a.b.c -> FieldAccess { object: FieldAccess { object: a, field: "b" }, field: "c" }
     let expr = parse_single_expr("a.b.c");
     assert_eq!(
         expr,
-        Expr::FieldAccess {
-            object: Box::new(Expr::FieldAccess {
-                object: Box::new(Expr::Identifier("a".to_string())),
+        e(ExprKind::FieldAccess {
+            object: Box::new(e(ExprKind::FieldAccess {
+                object: be(ExprKind::Identifier("a".to_string())),
                 field: "b".to_string(),
-            }),
+            })),
             field: "c".to_string(),
-        }
+        })
     );
 }
 
@@ -344,10 +357,10 @@ fn parse_safe_access() {
     let expr = parse_single_expr("user?.name");
     assert_eq!(
         expr,
-        Expr::SafeAccess {
-            object: Box::new(Expr::Identifier("user".to_string())),
+        e(ExprKind::SafeAccess {
+            object: be(ExprKind::Identifier("user".to_string())),
             field: "name".to_string(),
-        }
+        })
     );
 }
 
@@ -356,11 +369,11 @@ fn parse_method_call() {
     let expr = parse_single_expr("list.push(42)");
     assert_eq!(
         expr,
-        Expr::MethodCall {
-            object: Box::new(Expr::Identifier("list".to_string())),
+        e(ExprKind::MethodCall {
+            object: be(ExprKind::Identifier("list".to_string())),
             method: "push".to_string(),
-            args: vec![Expr::IntLiteral(42)],
-        }
+            args: vec![e(ExprKind::IntLiteral(42))],
+        })
     );
 }
 
@@ -369,10 +382,10 @@ fn parse_index_access() {
     let expr = parse_single_expr("items[0]");
     assert_eq!(
         expr,
-        Expr::Index {
-            object: Box::new(Expr::Identifier("items".to_string())),
-            index: Box::new(Expr::IntLiteral(0)),
-        }
+        e(ExprKind::Index {
+            object: be(ExprKind::Identifier("items".to_string())),
+            index: be(ExprKind::IntLiteral(0)),
+        })
     );
 }
 
@@ -381,46 +394,43 @@ fn parse_null_coalesce() {
     let expr = parse_single_expr("user?.name ?? \"Unknown\"");
     assert_eq!(
         expr,
-        Expr::NullCoalesce {
-            left: Box::new(Expr::SafeAccess {
-                object: Box::new(Expr::Identifier("user".to_string())),
+        e(ExprKind::NullCoalesce {
+            left: Box::new(e(ExprKind::SafeAccess {
+                object: be(ExprKind::Identifier("user".to_string())),
                 field: "name".to_string(),
-            }),
-            right: Box::new(Expr::StringLiteral("Unknown".to_string())),
-        }
+            })),
+            right: be(ExprKind::StringLiteral("Unknown".to_string())),
+        })
     );
 }
 
 #[test]
 fn parse_chained_method_calls() {
-    // a.foo().bar() -> MethodCall { object: FnCall on FieldAccess... }
-    // Actually: a.foo() is MethodCall, then .bar() is another MethodCall on the result
     let expr = parse_single_expr("a.foo().bar()");
     assert_eq!(
         expr,
-        Expr::MethodCall {
-            object: Box::new(Expr::MethodCall {
-                object: Box::new(Expr::Identifier("a".to_string())),
+        e(ExprKind::MethodCall {
+            object: Box::new(e(ExprKind::MethodCall {
+                object: be(ExprKind::Identifier("a".to_string())),
                 method: "foo".to_string(),
                 args: vec![],
-            }),
+            })),
             method: "bar".to_string(),
             args: vec![],
-        }
+        })
     );
 }
 
 #[test]
 fn parse_call_on_field() {
-    // obj.field(1, 2) is a method call
     let expr = parse_single_expr("obj.field(1, 2)");
     assert_eq!(
         expr,
-        Expr::MethodCall {
-            object: Box::new(Expr::Identifier("obj".to_string())),
+        e(ExprKind::MethodCall {
+            object: be(ExprKind::Identifier("obj".to_string())),
             method: "field".to_string(),
-            args: vec![Expr::IntLiteral(1), Expr::IntLiteral(2)],
-        }
+            args: vec![e(ExprKind::IntLiteral(1)), e(ExprKind::IntLiteral(2))],
+        })
     );
 }
 
@@ -431,12 +441,12 @@ fn parse_let_with_type() {
     let stmts = parse_ok("let x: i32 = 42");
     assert_eq!(
         stmts[0],
-        Stmt::Let {
+        s(StmtKind::Let {
             name: "x".to_string(),
             mutable: false,
             type_ann: Some(Type::Simple("i32".to_string())),
-            value: Expr::IntLiteral(42),
-        }
+            value: e(ExprKind::IntLiteral(42)),
+        })
     );
 }
 
@@ -445,12 +455,12 @@ fn parse_let_mutable() {
     let stmts = parse_ok("let mut count = 0");
     assert_eq!(
         stmts[0],
-        Stmt::Let {
+        s(StmtKind::Let {
             name: "count".to_string(),
             mutable: true,
             type_ann: None,
-            value: Expr::IntLiteral(0),
-        }
+            value: e(ExprKind::IntLiteral(0)),
+        })
     );
 }
 
@@ -459,12 +469,12 @@ fn parse_let_inferred() {
     let stmts = parse_ok("let name = \"Alice\"");
     assert_eq!(
         stmts[0],
-        Stmt::Let {
+        s(StmtKind::Let {
             name: "name".to_string(),
             mutable: false,
             type_ann: None,
-            value: Expr::StringLiteral("Alice".to_string()),
-        }
+            value: e(ExprKind::StringLiteral("Alice".to_string())),
+        })
     );
 }
 
@@ -473,16 +483,16 @@ fn parse_let_with_expression() {
     let stmts = parse_ok("let sum = a + b");
     assert_eq!(
         stmts[0],
-        Stmt::Let {
+        s(StmtKind::Let {
             name: "sum".to_string(),
             mutable: false,
             type_ann: None,
-            value: Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("a".to_string())),
+            value: e(ExprKind::BinaryOp {
+                left: be(ExprKind::Identifier("a".to_string())),
                 op: BinOp::Add,
-                right: Box::new(Expr::Identifier("b".to_string())),
-            },
-        }
+                right: be(ExprKind::Identifier("b".to_string())),
+            }),
+        })
     );
 }
 
@@ -491,18 +501,18 @@ fn parse_return_value() {
     let stmts = parse_ok("return x + 1");
     assert_eq!(
         stmts[0],
-        Stmt::Return(Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier("x".to_string())),
+        s(StmtKind::Return(Some(e(ExprKind::BinaryOp {
+            left: be(ExprKind::Identifier("x".to_string())),
             op: BinOp::Add,
-            right: Box::new(Expr::IntLiteral(1)),
-        }))
+            right: be(ExprKind::IntLiteral(1)),
+        }))))
     );
 }
 
 #[test]
 fn parse_return_void() {
     let stmts = parse_ok("return");
-    assert_eq!(stmts[0], Stmt::Return(None));
+    assert_eq!(stmts[0], s(StmtKind::Return(None)));
 }
 
 #[test]
@@ -510,18 +520,18 @@ fn parse_expression_statement() {
     let stmts = parse_ok("println(\"hello\")");
     assert_eq!(
         stmts[0],
-        Stmt::Expression(Expr::FnCall {
-            callee: Box::new(Expr::Identifier("println".to_string())),
-            args: vec![Expr::StringLiteral("hello".to_string())],
-        })
+        s(StmtKind::Expression(e(ExprKind::FnCall {
+            callee: be(ExprKind::Identifier("println".to_string())),
+            args: vec![e(ExprKind::StringLiteral("hello".to_string()))],
+        })))
     );
 }
 
 #[test]
 fn parse_nullable_type() {
     let stmts = parse_ok("let user: User? = find()");
-    match &stmts[0] {
-        Stmt::Let { type_ann, .. } => {
+    match &stmts[0].kind {
+        StmtKind::Let { type_ann, .. } => {
             assert_eq!(
                 *type_ann,
                 Some(Type::Nullable(Box::new(Type::Simple("User".to_string()))))
@@ -534,8 +544,8 @@ fn parse_nullable_type() {
 #[test]
 fn parse_generic_type() {
     let stmts = parse_ok("let items: Vec<i32> = create()");
-    match &stmts[0] {
-        Stmt::Let { type_ann, .. } => {
+    match &stmts[0].kind {
+        StmtKind::Let { type_ann, .. } => {
             assert_eq!(
                 *type_ann,
                 Some(Type::Generic {
@@ -551,8 +561,8 @@ fn parse_generic_type() {
 #[test]
 fn parse_reference_type() {
     let stmts = parse_ok("let name: &str = get()");
-    match &stmts[0] {
-        Stmt::Let { type_ann, .. } => {
+    match &stmts[0].kind {
+        StmtKind::Let { type_ann, .. } => {
             assert_eq!(
                 *type_ann,
                 Some(Type::Reference {
@@ -568,8 +578,8 @@ fn parse_reference_type() {
 #[test]
 fn parse_mutable_reference_type() {
     let stmts = parse_ok("let data: &mut i32 = get()");
-    match &stmts[0] {
-        Stmt::Let { type_ann, .. } => {
+    match &stmts[0].kind {
+        StmtKind::Let { type_ann, .. } => {
             assert_eq!(
                 *type_ann,
                 Some(Type::Reference {
@@ -585,8 +595,8 @@ fn parse_mutable_reference_type() {
 #[test]
 fn parse_multi_generic_type() {
     let stmts = parse_ok("let result: Result<i32, str> = try_it()");
-    match &stmts[0] {
-        Stmt::Let { type_ann, .. } => {
+    match &stmts[0].kind {
+        StmtKind::Let { type_ann, .. } => {
             assert_eq!(
                 *type_ann,
                 Some(Type::Generic {
@@ -609,16 +619,16 @@ fn parse_hello_world() {
     let stmts = parse_ok("fn main() {\n    println(\"Hello, Sage!\")\n}");
     assert_eq!(
         stmts[0],
-        Stmt::FnDef {
+        s(StmtKind::FnDef {
             name: "main".to_string(),
             params: vec![],
             return_type: None,
-            body: vec![Stmt::Expression(Expr::FnCall {
-                callee: Box::new(Expr::Identifier("println".to_string())),
-                args: vec![Expr::StringLiteral("Hello, Sage!".to_string())],
-            })],
+            body: vec![s(StmtKind::Expression(e(ExprKind::FnCall {
+                callee: be(ExprKind::Identifier("println".to_string())),
+                args: vec![e(ExprKind::StringLiteral("Hello, Sage!".to_string()))],
+            })))],
             decorators: vec![],
-        }
+        })
     );
 }
 
@@ -627,7 +637,7 @@ fn parse_fn_with_params_and_return() {
     let stmts = parse_ok("fn add(a: i32, b: i32) -> i32 {\n    return a + b\n}");
     assert_eq!(
         stmts[0],
-        Stmt::FnDef {
+        s(StmtKind::FnDef {
             name: "add".to_string(),
             params: vec![
                 Param {
@@ -640,21 +650,21 @@ fn parse_fn_with_params_and_return() {
                 },
             ],
             return_type: Some(Type::Simple("i32".to_string())),
-            body: vec![Stmt::Return(Some(Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("a".to_string())),
+            body: vec![s(StmtKind::Return(Some(e(ExprKind::BinaryOp {
+                left: be(ExprKind::Identifier("a".to_string())),
                 op: BinOp::Add,
-                right: Box::new(Expr::Identifier("b".to_string())),
-            }))],
+                right: be(ExprKind::Identifier("b".to_string())),
+            }))))],
             decorators: vec![],
-        }
+        })
     );
 }
 
 #[test]
 fn parse_fn_no_return_type() {
     let stmts = parse_ok("fn greet(name: str) {\n    println(name)\n}");
-    match &stmts[0] {
-        Stmt::FnDef {
+    match &stmts[0].kind {
+        StmtKind::FnDef {
             name,
             params,
             return_type,
@@ -672,12 +682,12 @@ fn parse_fn_no_return_type() {
 #[test]
 fn parse_fn_multiple_statements() {
     let stmts = parse_ok("fn calc() -> i32 {\n    let x = 1\n    let y = 2\n    return x + y\n}");
-    match &stmts[0] {
-        Stmt::FnDef { body, .. } => {
+    match &stmts[0].kind {
+        StmtKind::FnDef { body, .. } => {
             assert_eq!(body.len(), 3);
-            assert!(matches!(&body[0], Stmt::Let { name, .. } if name == "x"));
-            assert!(matches!(&body[1], Stmt::Let { name, .. } if name == "y"));
-            assert!(matches!(&body[2], Stmt::Return(Some(_))));
+            assert!(matches!(&body[0].kind, StmtKind::Let { name, .. } if name == "x"));
+            assert!(matches!(&body[1].kind, StmtKind::Let { name, .. } if name == "y"));
+            assert!(matches!(&body[2].kind, StmtKind::Return(Some(_))));
         }
         other => panic!("Expected FnDef, got {:?}", other),
     }
@@ -686,8 +696,8 @@ fn parse_fn_multiple_statements() {
 #[test]
 fn parse_fn_empty_body() {
     let stmts = parse_ok("fn noop() {}");
-    match &stmts[0] {
-        Stmt::FnDef { body, .. } => assert!(body.is_empty()),
+    match &stmts[0].kind {
+        StmtKind::FnDef { body, .. } => assert!(body.is_empty()),
         other => panic!("Expected FnDef, got {:?}", other),
     }
 }
@@ -697,8 +707,8 @@ fn parse_multiple_top_level_fns() {
     let src = "fn foo() {\n    1\n}\nfn bar() {\n    2\n}";
     let stmts = parse_ok(src);
     assert_eq!(stmts.len(), 2);
-    assert!(matches!(&stmts[0], Stmt::FnDef { name, .. } if name == "foo"));
-    assert!(matches!(&stmts[1], Stmt::FnDef { name, .. } if name == "bar"));
+    assert!(matches!(&stmts[0].kind, StmtKind::FnDef { name, .. } if name == "foo"));
+    assert!(matches!(&stmts[1].kind, StmtKind::FnDef { name, .. } if name == "bar"));
 }
 
 // -- Task 6: Control flow --
@@ -708,28 +718,28 @@ fn parse_if_else() {
     let expr = parse_single_expr("if x > 0 {\n    1\n} else {\n    2\n}");
     assert_eq!(
         expr,
-        Expr::IfElse {
-            condition: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("x".to_string())),
+        e(ExprKind::IfElse {
+            condition: Box::new(e(ExprKind::BinaryOp {
+                left: be(ExprKind::Identifier("x".to_string())),
                 op: BinOp::Gt,
-                right: Box::new(Expr::IntLiteral(0)),
-            }),
-            then_block: vec![Stmt::Expression(Expr::IntLiteral(1))],
-            else_block: Some(vec![Stmt::Expression(Expr::IntLiteral(2))]),
-        }
+                right: be(ExprKind::IntLiteral(0)),
+            })),
+            then_block: vec![s(StmtKind::Expression(e(ExprKind::IntLiteral(1))))],
+            else_block: Some(vec![s(StmtKind::Expression(e(ExprKind::IntLiteral(2))))]),
+        })
     );
 }
 
 #[test]
 fn parse_if_no_else() {
     let expr = parse_single_expr("if flag {\n    do_stuff()\n}");
-    match expr {
-        Expr::IfElse {
+    match expr.kind {
+        ExprKind::IfElse {
             condition,
             then_block,
             else_block,
         } => {
-            assert_eq!(*condition, Expr::Identifier("flag".to_string()));
+            assert_eq!(*condition, e(ExprKind::Identifier("flag".to_string())));
             assert_eq!(then_block.len(), 1);
             assert!(else_block.is_none());
         }
@@ -740,21 +750,24 @@ fn parse_if_no_else() {
 #[test]
 fn parse_if_else_if() {
     let expr = parse_single_expr("if a {\n    1\n} else if b {\n    2\n} else {\n    3\n}");
-    match expr {
-        Expr::IfElse {
+    match expr.kind {
+        ExprKind::IfElse {
             else_block: Some(else_stmts),
             ..
         } => {
             // else branch contains an expression statement wrapping another IfElse
             assert_eq!(else_stmts.len(), 1);
-            match &else_stmts[0] {
-                Stmt::Expression(Expr::IfElse {
-                    else_block: Some(inner_else),
-                    ..
-                }) => {
-                    assert_eq!(inner_else.len(), 1);
-                }
-                other => panic!("Expected nested IfElse, got {:?}", other),
+            match &else_stmts[0].kind {
+                StmtKind::Expression(inner) => match &inner.kind {
+                    ExprKind::IfElse {
+                        else_block: Some(inner_else),
+                        ..
+                    } => {
+                        assert_eq!(inner_else.len(), 1);
+                    }
+                    other => panic!("Expected nested IfElse, got {:?}", other),
+                },
+                other => panic!("Expected Expression, got {:?}", other),
             }
         }
         other => panic!("Expected IfElse with else, got {:?}", other),
@@ -764,10 +777,10 @@ fn parse_if_else_if() {
 #[test]
 fn parse_for_loop() {
     let stmts = parse_ok("for i in items {\n    println(i)\n}");
-    match &stmts[0] {
-        Stmt::ForLoop { var, iter, body } => {
+    match &stmts[0].kind {
+        StmtKind::ForLoop { var, iter, body } => {
             assert_eq!(var, "i");
-            assert_eq!(*iter, Expr::Identifier("items".to_string()));
+            assert_eq!(*iter, e(ExprKind::Identifier("items".to_string())));
             assert_eq!(body.len(), 1);
         }
         other => panic!("Expected ForLoop, got {:?}", other),
@@ -777,12 +790,10 @@ fn parse_for_loop() {
 #[test]
 fn parse_for_loop_range() {
     let stmts = parse_ok("for i in 0..10 {\n    println(i)\n}");
-    match &stmts[0] {
-        Stmt::ForLoop { var, iter, .. } => {
+    match &stmts[0].kind {
+        StmtKind::ForLoop { var, iter, .. } => {
             assert_eq!(var, "i");
-            // 0..10 parses as BinaryOp with DotDot - but we don't have DotDot as a binop yet
-            // For now it's just the expression after 'in'
-            assert!(matches!(iter, Expr::BinaryOp { .. }));
+            assert!(matches!(iter.kind, ExprKind::BinaryOp { .. }));
         }
         other => panic!("Expected ForLoop, got {:?}", other),
     }
@@ -791,11 +802,14 @@ fn parse_for_loop_range() {
 #[test]
 fn parse_while_loop() {
     let stmts = parse_ok("while count < 10 {\n    process(count)\n}");
-    match &stmts[0] {
-        Stmt::WhileLoop {
+    match &stmts[0].kind {
+        StmtKind::WhileLoop {
             condition, body, ..
         } => {
-            assert!(matches!(condition, Expr::BinaryOp { op: BinOp::Lt, .. }));
+            assert!(matches!(
+                condition.kind,
+                ExprKind::BinaryOp { op: BinOp::Lt, .. }
+            ));
             assert_eq!(body.len(), 1);
         }
         other => panic!("Expected WhileLoop, got {:?}", other),
@@ -806,16 +820,16 @@ fn parse_while_loop() {
 fn parse_match_expression() {
     let expr =
         parse_single_expr("match x {\n    1 => \"one\"\n    2 => \"two\"\n    _ => \"other\"\n}");
-    match expr {
-        Expr::Match {
+    match expr.kind {
+        ExprKind::Match {
             expr: matched,
             arms,
         } => {
-            assert_eq!(*matched, Expr::Identifier("x".to_string()));
+            assert_eq!(*matched, e(ExprKind::Identifier("x".to_string())));
             assert_eq!(arms.len(), 3);
-            assert_eq!(arms[0].pattern, Expr::IntLiteral(1));
-            assert_eq!(arms[0].body, Expr::StringLiteral("one".to_string()));
-            assert_eq!(arms[2].pattern, Expr::Identifier("_".to_string()));
+            assert_eq!(arms[0].pattern, e(ExprKind::IntLiteral(1)));
+            assert_eq!(arms[0].body, e(ExprKind::StringLiteral("one".to_string())));
+            assert_eq!(arms[2].pattern, e(ExprKind::Identifier("_".to_string())));
         }
         other => panic!("Expected Match, got {:?}", other),
     }
@@ -824,8 +838,8 @@ fn parse_match_expression() {
 #[test]
 fn parse_match_with_commas() {
     let expr = parse_single_expr("match x { 1 => \"a\", 2 => \"b\" }");
-    match expr {
-        Expr::Match { arms, .. } => {
+    match expr.kind {
+        ExprKind::Match { arms, .. } => {
             assert_eq!(arms.len(), 2);
         }
         other => panic!("Expected Match, got {:?}", other),
@@ -839,7 +853,7 @@ fn parse_struct_def() {
     let stmts = parse_ok("struct User {\n    name: str\n    age: i32\n}");
     assert_eq!(
         stmts[0],
-        Stmt::StructDef {
+        s(StmtKind::StructDef {
             name: "User".to_string(),
             fields: vec![
                 Field {
@@ -851,15 +865,15 @@ fn parse_struct_def() {
                     type_ann: Type::Simple("i32".to_string()),
                 },
             ],
-        }
+        })
     );
 }
 
 #[test]
 fn parse_struct_comma_separated() {
     let stmts = parse_ok("struct Point { x: f64, y: f64 }");
-    match &stmts[0] {
-        Stmt::StructDef { name, fields } => {
+    match &stmts[0].kind {
+        StmtKind::StructDef { name, fields } => {
             assert_eq!(name, "Point");
             assert_eq!(fields.len(), 2);
         }
@@ -872,10 +886,10 @@ fn parse_struct_empty() {
     let stmts = parse_ok("struct Empty {}");
     assert_eq!(
         stmts[0],
-        Stmt::StructDef {
+        s(StmtKind::StructDef {
             name: "Empty".to_string(),
             fields: vec![],
-        }
+        })
     );
 }
 
@@ -884,7 +898,7 @@ fn parse_trait_def() {
     let stmts = parse_ok("trait Greetable {\n    fn greet(self) -> str\n}");
     assert_eq!(
         stmts[0],
-        Stmt::TraitDef {
+        s(StmtKind::TraitDef {
             name: "Greetable".to_string(),
             methods: vec![FnSignature {
                 name: "greet".to_string(),
@@ -894,15 +908,15 @@ fn parse_trait_def() {
                 }],
                 return_type: Some(Type::Simple("str".to_string())),
             }],
-        }
+        })
     );
 }
 
 #[test]
 fn parse_trait_multiple_methods() {
     let stmts = parse_ok("trait Animal {\n    fn name(self) -> str\n    fn speak(self) -> str\n}");
-    match &stmts[0] {
-        Stmt::TraitDef { methods, .. } => {
+    match &stmts[0].kind {
+        StmtKind::TraitDef { methods, .. } => {
             assert_eq!(methods.len(), 2);
             assert_eq!(methods[0].name, "name");
             assert_eq!(methods[1].name, "speak");
@@ -914,8 +928,8 @@ fn parse_trait_multiple_methods() {
 #[test]
 fn parse_impl_block() {
     let stmts = parse_ok("impl User {\n    fn new(name: str) -> User {\n        name\n    }\n}");
-    match &stmts[0] {
-        Stmt::ImplBlock {
+    match &stmts[0].kind {
+        StmtKind::ImplBlock {
             trait_name,
             target,
             methods,
@@ -923,7 +937,7 @@ fn parse_impl_block() {
             assert!(trait_name.is_none());
             assert_eq!(target, "User");
             assert_eq!(methods.len(), 1);
-            assert!(matches!(&methods[0], Stmt::FnDef { name, .. } if name == "new"));
+            assert!(matches!(&methods[0].kind, StmtKind::FnDef { name, .. } if name == "new"));
         }
         other => panic!("Expected ImplBlock, got {:?}", other),
     }
@@ -934,8 +948,8 @@ fn parse_impl_trait_for_type() {
     let stmts = parse_ok(
         "impl Greetable for User {\n    fn greet(self) -> str {\n        self.name\n    }\n}",
     );
-    match &stmts[0] {
-        Stmt::ImplBlock {
+    match &stmts[0].kind {
+        StmtKind::ImplBlock {
             trait_name,
             target,
             methods,
@@ -953,8 +967,8 @@ fn parse_impl_trait_for_type() {
 #[test]
 fn parse_decorator_simple() {
     let stmts = parse_ok("@tool\nfn lookup() {}");
-    match &stmts[0] {
-        Stmt::FnDef {
+    match &stmts[0].kind {
+        StmtKind::FnDef {
             name, decorators, ..
         } => {
             assert_eq!(name, "lookup");
@@ -969,15 +983,15 @@ fn parse_decorator_simple() {
 #[test]
 fn parse_decorator_with_args() {
     let stmts = parse_ok("@tool(description: \"look up a user\")\nfn lookup() {}");
-    match &stmts[0] {
-        Stmt::FnDef { decorators, .. } => {
+    match &stmts[0].kind {
+        StmtKind::FnDef { decorators, .. } => {
             assert_eq!(decorators.len(), 1);
             assert_eq!(decorators[0].name, "tool");
             assert_eq!(decorators[0].args.len(), 1);
             assert_eq!(decorators[0].args[0].0, "description");
             assert_eq!(
                 decorators[0].args[0].1,
-                Expr::StringLiteral("look up a user".to_string())
+                e(ExprKind::StringLiteral("look up a user".to_string()))
             );
         }
         other => panic!("Expected FnDef, got {:?}", other),
@@ -987,8 +1001,8 @@ fn parse_decorator_with_args() {
 #[test]
 fn parse_multiple_decorators() {
     let stmts = parse_ok("@mcp_server\n@tool\nfn handler() {}");
-    match &stmts[0] {
-        Stmt::FnDef { decorators, .. } => {
+    match &stmts[0].kind {
+        StmtKind::FnDef { decorators, .. } => {
             assert_eq!(decorators.len(), 2);
             assert_eq!(decorators[0].name, "mcp_server");
             assert_eq!(decorators[1].name, "tool");
@@ -1002,9 +1016,9 @@ fn parse_import() {
     let stmts = parse_ok("import std.io");
     assert_eq!(
         stmts[0],
-        Stmt::Import {
+        s(StmtKind::Import {
             path: vec!["std".to_string(), "io".to_string()],
-        }
+        })
     );
 }
 
@@ -1013,21 +1027,21 @@ fn parse_import_deep() {
     let stmts = parse_ok("import std.collections.HashMap");
     assert_eq!(
         stmts[0],
-        Stmt::Import {
+        s(StmtKind::Import {
             path: vec![
                 "std".to_string(),
                 "collections".to_string(),
                 "HashMap".to_string(),
             ],
-        }
+        })
     );
 }
 
 #[test]
 fn parse_try_catch() {
     let stmts = parse_ok("try {\n    risky()\n} catch e {\n    handle(e)\n}");
-    match &stmts[0] {
-        Stmt::TryCatch {
+    match &stmts[0].kind {
+        StmtKind::TryCatch {
             try_block,
             catch_var,
             catch_block,
@@ -1043,8 +1057,8 @@ fn parse_try_catch() {
 #[test]
 fn parse_test_fn() {
     let stmts = parse_ok("test \"addition works\" {\n    assert_eq(1 + 1, 2)\n}");
-    match &stmts[0] {
-        Stmt::TestFn { name, body } => {
+    match &stmts[0].kind {
+        StmtKind::TestFn { name, body } => {
             assert_eq!(name, "addition works");
             assert_eq!(body.len(), 1);
         }
@@ -1055,8 +1069,8 @@ fn parse_test_fn() {
 #[test]
 fn parse_closure_simple() {
     let expr = parse_single_expr("|x| x + 1");
-    match expr {
-        Expr::Closure { params, body } => {
+    match expr.kind {
+        ExprKind::Closure { params, body } => {
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "x");
             assert_eq!(body.len(), 1);
@@ -1068,8 +1082,8 @@ fn parse_closure_simple() {
 #[test]
 fn parse_closure_multiple_params() {
     let expr = parse_single_expr("|a, b| a + b");
-    match expr {
-        Expr::Closure { params, .. } => {
+    match expr.kind {
+        ExprKind::Closure { params, .. } => {
             assert_eq!(params.len(), 2);
             assert_eq!(params[0].name, "a");
             assert_eq!(params[1].name, "b");
@@ -1081,13 +1095,16 @@ fn parse_closure_multiple_params() {
 #[test]
 fn parse_closure_with_block() {
     let stmts = parse_ok("|a, b| {\n    return a + b\n}");
-    match &stmts[0] {
-        Stmt::Expression(Expr::Closure { params, body }) => {
-            assert_eq!(params.len(), 2);
-            assert_eq!(body.len(), 1);
-            assert!(matches!(&body[0], Stmt::Return(Some(_))));
-        }
-        other => panic!("Expected Closure, got {:?}", other),
+    match &stmts[0].kind {
+        StmtKind::Expression(closure) => match &closure.kind {
+            ExprKind::Closure { params, body } => {
+                assert_eq!(params.len(), 2);
+                assert_eq!(body.len(), 1);
+                assert!(matches!(&body[0].kind, StmtKind::Return(Some(_))));
+            }
+            other => panic!("Expected Closure, got {:?}", other),
+        },
+        other => panic!("Expected Expression, got {:?}", other),
     }
 }
 
@@ -1096,30 +1113,30 @@ fn parse_list_literal() {
     let expr = parse_single_expr("[1, 2, 3]");
     assert_eq!(
         expr,
-        Expr::ListLiteral(vec![
-            Expr::IntLiteral(1),
-            Expr::IntLiteral(2),
-            Expr::IntLiteral(3),
-        ])
+        e(ExprKind::ListLiteral(vec![
+            e(ExprKind::IntLiteral(1)),
+            e(ExprKind::IntLiteral(2)),
+            e(ExprKind::IntLiteral(3)),
+        ]))
     );
 }
 
 #[test]
 fn parse_list_empty() {
     let expr = parse_single_expr("[]");
-    assert_eq!(expr, Expr::ListLiteral(vec![]));
+    assert_eq!(expr, e(ExprKind::ListLiteral(vec![])));
 }
 
 #[test]
 fn parse_string_interpolation() {
     let expr = parse_single_expr("\"Hello {name}!\"");
-    match expr {
-        Expr::StringInterpolation { parts } => {
+    match expr.kind {
+        ExprKind::StringInterpolation { parts } => {
             assert_eq!(parts.len(), 3);
             assert_eq!(parts[0], StringPart::Literal("Hello ".to_string()));
             assert_eq!(
                 parts[1],
-                StringPart::Expr(Expr::Identifier("name".to_string()))
+                StringPart::Expr(e(ExprKind::Identifier("name".to_string())))
             );
             assert_eq!(parts[2], StringPart::Literal("!".to_string()));
         }
@@ -1130,9 +1147,9 @@ fn parse_string_interpolation() {
 #[test]
 fn parse_spawn() {
     let expr = parse_single_expr("spawn fetch_data()");
-    match expr {
-        Expr::Spawn(inner) => {
-            assert!(matches!(*inner, Expr::FnCall { .. }));
+    match expr.kind {
+        ExprKind::Spawn(inner) => {
+            assert!(matches!(inner.kind, ExprKind::FnCall { .. }));
         }
         other => panic!("Expected Spawn, got {:?}", other),
     }
@@ -1141,17 +1158,20 @@ fn parse_spawn() {
 #[test]
 fn parse_parallel() {
     let stmts = parse_ok("parallel items |item| {\n    process(item)\n}");
-    match &stmts[0] {
-        Stmt::Expression(Expr::Parallel {
-            collection,
-            param,
-            body,
-        }) => {
-            assert_eq!(**collection, Expr::Identifier("items".to_string()));
-            assert_eq!(param, "item");
-            assert!(matches!(**body, Expr::Closure { .. }));
-        }
-        other => panic!("Expected Parallel, got {:?}", other),
+    match &stmts[0].kind {
+        StmtKind::Expression(expr) => match &expr.kind {
+            ExprKind::Parallel {
+                collection,
+                param,
+                body,
+            } => {
+                assert_eq!(**collection, e(ExprKind::Identifier("items".to_string())));
+                assert_eq!(param, "item");
+                assert!(matches!(body.kind, ExprKind::Closure { .. }));
+            }
+            other => panic!("Expected Parallel, got {:?}", other),
+        },
+        other => panic!("Expected Expression, got {:?}", other),
     }
 }
 
@@ -1179,7 +1199,7 @@ fn parse_error_recovery_continues() {
     assert!(
         stmts
             .iter()
-            .any(|s| matches!(s, Stmt::Let { name, .. } if name == "y")),
+            .any(|s| matches!(&s.kind, StmtKind::Let { name, .. } if name == "y")),
         "Should recover and parse second let statement"
     );
 }
@@ -1192,4 +1212,101 @@ fn parse_multiple_errors() {
         "Should report multiple errors, got {}",
         errors.len()
     );
+}
+
+// -- Fix verification tests --
+
+#[test]
+fn fix2_depth_limit_prevents_stack_overflow() {
+    // Build deeply nested parens: (((((...42...)))))
+    let depth = 200;
+    let mut src = String::new();
+    for _ in 0..depth {
+        src.push('(');
+    }
+    src.push_str("42");
+    for _ in 0..depth {
+        src.push(')');
+    }
+    let (_, errors) = parse(&src);
+    assert!(
+        errors.iter().any(|e| e.message.contains("depth exceeded")),
+        "Should error on deeply nested expressions"
+    );
+}
+
+#[test]
+fn fix3_synchronize_no_infinite_loop() {
+    // This used to infinite loop: synchronize lands on 'let', parse fails on same 'let' again
+    let (_, errors) = parse("let = 1\nlet = 2\nlet = 3");
+    // Should terminate and report multiple errors
+    assert!(
+        errors.len() >= 3,
+        "Should report errors, got {}",
+        errors.len()
+    );
+}
+
+#[test]
+fn fix4_decorator_on_non_fn_is_error() {
+    let (_, errors) = parse("@cached\nlet x = 5");
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.message.contains("Decorators are only valid")),
+        "Should error on decorator before let"
+    );
+}
+
+#[test]
+fn fix5_parallel_empty_closure_is_error() {
+    let (_, errors) = parse("parallel items || { process() }");
+    assert!(
+        !errors.is_empty(),
+        "Should error on parallel with empty closure params"
+    );
+}
+
+#[test]
+fn fix7_nullish_coalescing_mixed_with_logical_is_error() {
+    let (_, errors) = parse("a ?? b || c");
+    assert!(
+        errors.iter().any(|e| e.message.contains("Cannot mix")),
+        "Should error on ?? mixed with ||"
+    );
+
+    let (_, errors) = parse("a || b ?? c");
+    assert!(
+        errors.iter().any(|e| e.message.contains("Cannot mix")),
+        "Should error on || mixed with ??"
+    );
+}
+
+#[test]
+fn fix7_nullish_coalescing_with_parens_is_ok() {
+    // Parenthesized sub-expressions should be fine
+    let _ = parse_ok("(a ?? b) || c");
+    let _ = parse_ok("a ?? (b || c)");
+}
+
+#[test]
+fn fix1_exprs_have_spans() {
+    let stmts = parse_ok("42");
+    // The expression statement should carry a non-default span
+    assert!(
+        stmts[0].span.line > 0
+            || stmts[0].span.column > 0
+            || stmts[0].span.start > 0
+            || stmts[0].span.end > 0,
+        "Stmt should have a non-trivial span"
+    );
+    match &stmts[0].kind {
+        StmtKind::Expression(expr) => {
+            assert!(
+                expr.span.end > expr.span.start,
+                "Expr span should cover the literal"
+            );
+        }
+        other => panic!("Expected Expression, got {:?}", other),
+    }
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -947,3 +947,210 @@ fn parse_impl_trait_for_type() {
         other => panic!("Expected ImplBlock, got {:?}", other),
     }
 }
+
+// -- Task 8: Decorators, imports, closures, concurrency, etc --
+
+#[test]
+fn parse_decorator_simple() {
+    let stmts = parse_ok("@tool\nfn lookup() {}");
+    match &stmts[0] {
+        Stmt::FnDef {
+            name, decorators, ..
+        } => {
+            assert_eq!(name, "lookup");
+            assert_eq!(decorators.len(), 1);
+            assert_eq!(decorators[0].name, "tool");
+            assert!(decorators[0].args.is_empty());
+        }
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_decorator_with_args() {
+    let stmts = parse_ok("@tool(description: \"look up a user\")\nfn lookup() {}");
+    match &stmts[0] {
+        Stmt::FnDef { decorators, .. } => {
+            assert_eq!(decorators.len(), 1);
+            assert_eq!(decorators[0].name, "tool");
+            assert_eq!(decorators[0].args.len(), 1);
+            assert_eq!(decorators[0].args[0].0, "description");
+            assert_eq!(
+                decorators[0].args[0].1,
+                Expr::StringLiteral("look up a user".to_string())
+            );
+        }
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_multiple_decorators() {
+    let stmts = parse_ok("@mcp_server\n@tool\nfn handler() {}");
+    match &stmts[0] {
+        Stmt::FnDef { decorators, .. } => {
+            assert_eq!(decorators.len(), 2);
+            assert_eq!(decorators[0].name, "mcp_server");
+            assert_eq!(decorators[1].name, "tool");
+        }
+        other => panic!("Expected FnDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_import() {
+    let stmts = parse_ok("import std.io");
+    assert_eq!(
+        stmts[0],
+        Stmt::Import {
+            path: vec!["std".to_string(), "io".to_string()],
+        }
+    );
+}
+
+#[test]
+fn parse_import_deep() {
+    let stmts = parse_ok("import std.collections.HashMap");
+    assert_eq!(
+        stmts[0],
+        Stmt::Import {
+            path: vec![
+                "std".to_string(),
+                "collections".to_string(),
+                "HashMap".to_string(),
+            ],
+        }
+    );
+}
+
+#[test]
+fn parse_try_catch() {
+    let stmts = parse_ok("try {\n    risky()\n} catch e {\n    handle(e)\n}");
+    match &stmts[0] {
+        Stmt::TryCatch {
+            try_block,
+            catch_var,
+            catch_block,
+        } => {
+            assert_eq!(try_block.len(), 1);
+            assert_eq!(catch_var, "e");
+            assert_eq!(catch_block.len(), 1);
+        }
+        other => panic!("Expected TryCatch, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_test_fn() {
+    let stmts = parse_ok("test \"addition works\" {\n    assert_eq(1 + 1, 2)\n}");
+    match &stmts[0] {
+        Stmt::TestFn { name, body } => {
+            assert_eq!(name, "addition works");
+            assert_eq!(body.len(), 1);
+        }
+        other => panic!("Expected TestFn, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_closure_simple() {
+    let expr = parse_single_expr("|x| x + 1");
+    match expr {
+        Expr::Closure { params, body } => {
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "x");
+            assert_eq!(body.len(), 1);
+        }
+        other => panic!("Expected Closure, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_closure_multiple_params() {
+    let expr = parse_single_expr("|a, b| a + b");
+    match expr {
+        Expr::Closure { params, .. } => {
+            assert_eq!(params.len(), 2);
+            assert_eq!(params[0].name, "a");
+            assert_eq!(params[1].name, "b");
+        }
+        other => panic!("Expected Closure, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_closure_with_block() {
+    let stmts = parse_ok("|a, b| {\n    return a + b\n}");
+    match &stmts[0] {
+        Stmt::Expression(Expr::Closure { params, body }) => {
+            assert_eq!(params.len(), 2);
+            assert_eq!(body.len(), 1);
+            assert!(matches!(&body[0], Stmt::Return(Some(_))));
+        }
+        other => panic!("Expected Closure, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_list_literal() {
+    let expr = parse_single_expr("[1, 2, 3]");
+    assert_eq!(
+        expr,
+        Expr::ListLiteral(vec![
+            Expr::IntLiteral(1),
+            Expr::IntLiteral(2),
+            Expr::IntLiteral(3),
+        ])
+    );
+}
+
+#[test]
+fn parse_list_empty() {
+    let expr = parse_single_expr("[]");
+    assert_eq!(expr, Expr::ListLiteral(vec![]));
+}
+
+#[test]
+fn parse_string_interpolation() {
+    let expr = parse_single_expr("\"Hello {name}!\"");
+    match expr {
+        Expr::StringInterpolation { parts } => {
+            assert_eq!(parts.len(), 3);
+            assert_eq!(parts[0], StringPart::Literal("Hello ".to_string()));
+            assert_eq!(
+                parts[1],
+                StringPart::Expr(Expr::Identifier("name".to_string()))
+            );
+            assert_eq!(parts[2], StringPart::Literal("!".to_string()));
+        }
+        other => panic!("Expected StringInterpolation, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_spawn() {
+    let expr = parse_single_expr("spawn fetch_data()");
+    match expr {
+        Expr::Spawn(inner) => {
+            assert!(matches!(*inner, Expr::FnCall { .. }));
+        }
+        other => panic!("Expected Spawn, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_parallel() {
+    let stmts = parse_ok("parallel items |item| {\n    process(item)\n}");
+    match &stmts[0] {
+        Stmt::Expression(Expr::Parallel {
+            collection,
+            param,
+            body,
+        }) => {
+            assert_eq!(**collection, Expr::Identifier("items".to_string()));
+            assert_eq!(param, "item");
+            assert!(matches!(**body, Expr::Closure { .. }));
+        }
+        other => panic!("Expected Parallel, got {:?}", other),
+    }
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -700,3 +700,134 @@ fn parse_multiple_top_level_fns() {
     assert!(matches!(&stmts[0], Stmt::FnDef { name, .. } if name == "foo"));
     assert!(matches!(&stmts[1], Stmt::FnDef { name, .. } if name == "bar"));
 }
+
+// -- Task 6: Control flow --
+
+#[test]
+fn parse_if_else() {
+    let expr = parse_single_expr("if x > 0 {\n    1\n} else {\n    2\n}");
+    assert_eq!(
+        expr,
+        Expr::IfElse {
+            condition: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("x".to_string())),
+                op: BinOp::Gt,
+                right: Box::new(Expr::IntLiteral(0)),
+            }),
+            then_block: vec![Stmt::Expression(Expr::IntLiteral(1))],
+            else_block: Some(vec![Stmt::Expression(Expr::IntLiteral(2))]),
+        }
+    );
+}
+
+#[test]
+fn parse_if_no_else() {
+    let expr = parse_single_expr("if flag {\n    do_stuff()\n}");
+    match expr {
+        Expr::IfElse {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            assert_eq!(*condition, Expr::Identifier("flag".to_string()));
+            assert_eq!(then_block.len(), 1);
+            assert!(else_block.is_none());
+        }
+        other => panic!("Expected IfElse, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_if_else_if() {
+    let expr = parse_single_expr("if a {\n    1\n} else if b {\n    2\n} else {\n    3\n}");
+    match expr {
+        Expr::IfElse {
+            else_block: Some(else_stmts),
+            ..
+        } => {
+            // else branch contains an expression statement wrapping another IfElse
+            assert_eq!(else_stmts.len(), 1);
+            match &else_stmts[0] {
+                Stmt::Expression(Expr::IfElse {
+                    else_block: Some(inner_else),
+                    ..
+                }) => {
+                    assert_eq!(inner_else.len(), 1);
+                }
+                other => panic!("Expected nested IfElse, got {:?}", other),
+            }
+        }
+        other => panic!("Expected IfElse with else, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_for_loop() {
+    let stmts = parse_ok("for i in items {\n    println(i)\n}");
+    match &stmts[0] {
+        Stmt::ForLoop { var, iter, body } => {
+            assert_eq!(var, "i");
+            assert_eq!(*iter, Expr::Identifier("items".to_string()));
+            assert_eq!(body.len(), 1);
+        }
+        other => panic!("Expected ForLoop, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_for_loop_range() {
+    let stmts = parse_ok("for i in 0..10 {\n    println(i)\n}");
+    match &stmts[0] {
+        Stmt::ForLoop { var, iter, .. } => {
+            assert_eq!(var, "i");
+            // 0..10 parses as BinaryOp with DotDot - but we don't have DotDot as a binop yet
+            // For now it's just the expression after 'in'
+            assert!(matches!(iter, Expr::BinaryOp { .. }));
+        }
+        other => panic!("Expected ForLoop, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_while_loop() {
+    let stmts = parse_ok("while count < 10 {\n    process(count)\n}");
+    match &stmts[0] {
+        Stmt::WhileLoop {
+            condition, body, ..
+        } => {
+            assert!(matches!(condition, Expr::BinaryOp { op: BinOp::Lt, .. }));
+            assert_eq!(body.len(), 1);
+        }
+        other => panic!("Expected WhileLoop, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_match_expression() {
+    let expr =
+        parse_single_expr("match x {\n    1 => \"one\"\n    2 => \"two\"\n    _ => \"other\"\n}");
+    match expr {
+        Expr::Match {
+            expr: matched,
+            arms,
+        } => {
+            assert_eq!(*matched, Expr::Identifier("x".to_string()));
+            assert_eq!(arms.len(), 3);
+            assert_eq!(arms[0].pattern, Expr::IntLiteral(1));
+            assert_eq!(arms[0].body, Expr::StringLiteral("one".to_string()));
+            assert_eq!(arms[2].pattern, Expr::Identifier("_".to_string()));
+        }
+        other => panic!("Expected Match, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_match_with_commas() {
+    let expr = parse_single_expr("match x { 1 => \"a\", 2 => \"b\" }");
+    match expr {
+        Expr::Match { arms, .. } => {
+            assert_eq!(arms.len(), 2);
+        }
+        other => panic!("Expected Match, got {:?}", other),
+    }
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -423,3 +423,181 @@ fn parse_call_on_field() {
         }
     );
 }
+
+// -- Task 4: Let, return, type annotations --
+
+#[test]
+fn parse_let_with_type() {
+    let stmts = parse_ok("let x: i32 = 42");
+    assert_eq!(
+        stmts[0],
+        Stmt::Let {
+            name: "x".to_string(),
+            mutable: false,
+            type_ann: Some(Type::Simple("i32".to_string())),
+            value: Expr::IntLiteral(42),
+        }
+    );
+}
+
+#[test]
+fn parse_let_mutable() {
+    let stmts = parse_ok("let mut count = 0");
+    assert_eq!(
+        stmts[0],
+        Stmt::Let {
+            name: "count".to_string(),
+            mutable: true,
+            type_ann: None,
+            value: Expr::IntLiteral(0),
+        }
+    );
+}
+
+#[test]
+fn parse_let_inferred() {
+    let stmts = parse_ok("let name = \"Alice\"");
+    assert_eq!(
+        stmts[0],
+        Stmt::Let {
+            name: "name".to_string(),
+            mutable: false,
+            type_ann: None,
+            value: Expr::StringLiteral("Alice".to_string()),
+        }
+    );
+}
+
+#[test]
+fn parse_let_with_expression() {
+    let stmts = parse_ok("let sum = a + b");
+    assert_eq!(
+        stmts[0],
+        Stmt::Let {
+            name: "sum".to_string(),
+            mutable: false,
+            type_ann: None,
+            value: Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("a".to_string())),
+                op: BinOp::Add,
+                right: Box::new(Expr::Identifier("b".to_string())),
+            },
+        }
+    );
+}
+
+#[test]
+fn parse_return_value() {
+    let stmts = parse_ok("return x + 1");
+    assert_eq!(
+        stmts[0],
+        Stmt::Return(Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier("x".to_string())),
+            op: BinOp::Add,
+            right: Box::new(Expr::IntLiteral(1)),
+        }))
+    );
+}
+
+#[test]
+fn parse_return_void() {
+    let stmts = parse_ok("return");
+    assert_eq!(stmts[0], Stmt::Return(None));
+}
+
+#[test]
+fn parse_expression_statement() {
+    let stmts = parse_ok("println(\"hello\")");
+    assert_eq!(
+        stmts[0],
+        Stmt::Expression(Expr::FnCall {
+            callee: Box::new(Expr::Identifier("println".to_string())),
+            args: vec![Expr::StringLiteral("hello".to_string())],
+        })
+    );
+}
+
+#[test]
+fn parse_nullable_type() {
+    let stmts = parse_ok("let user: User? = find()");
+    match &stmts[0] {
+        Stmt::Let { type_ann, .. } => {
+            assert_eq!(
+                *type_ann,
+                Some(Type::Nullable(Box::new(Type::Simple("User".to_string()))))
+            );
+        }
+        other => panic!("Expected Let, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_generic_type() {
+    let stmts = parse_ok("let items: Vec<i32> = create()");
+    match &stmts[0] {
+        Stmt::Let { type_ann, .. } => {
+            assert_eq!(
+                *type_ann,
+                Some(Type::Generic {
+                    name: "Vec".to_string(),
+                    params: vec![Type::Simple("i32".to_string())],
+                })
+            );
+        }
+        other => panic!("Expected Let, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_reference_type() {
+    let stmts = parse_ok("let name: &str = get()");
+    match &stmts[0] {
+        Stmt::Let { type_ann, .. } => {
+            assert_eq!(
+                *type_ann,
+                Some(Type::Reference {
+                    mutable: false,
+                    inner: Box::new(Type::Simple("str".to_string())),
+                })
+            );
+        }
+        other => panic!("Expected Let, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_mutable_reference_type() {
+    let stmts = parse_ok("let data: &mut i32 = get()");
+    match &stmts[0] {
+        Stmt::Let { type_ann, .. } => {
+            assert_eq!(
+                *type_ann,
+                Some(Type::Reference {
+                    mutable: true,
+                    inner: Box::new(Type::Simple("i32".to_string())),
+                })
+            );
+        }
+        other => panic!("Expected Let, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_multi_generic_type() {
+    let stmts = parse_ok("let result: Result<i32, str> = try_it()");
+    match &stmts[0] {
+        Stmt::Let { type_ann, .. } => {
+            assert_eq!(
+                *type_ann,
+                Some(Type::Generic {
+                    name: "Result".to_string(),
+                    params: vec![
+                        Type::Simple("i32".to_string()),
+                        Type::Simple("str".to_string()),
+                    ],
+                })
+            );
+        }
+        other => panic!("Expected Let, got {:?}", other),
+    }
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -22,6 +22,15 @@ fn parse_ok(source: &str) -> Vec<Stmt> {
     stmts
 }
 
+fn parse_single_expr(source: &str) -> Expr {
+    let stmts = parse_ok(source);
+    assert_eq!(stmts.len(), 1, "Expected 1 statement, got {}", stmts.len());
+    match stmts.into_iter().next().unwrap() {
+        Stmt::Expression(expr) => expr,
+        other => panic!("Expected expression statement, got {:?}", other),
+    }
+}
+
 #[test]
 fn parser_constructs_without_panic() {
     let _ = parse_ok("");
@@ -31,4 +40,235 @@ fn parser_constructs_without_panic() {
 fn parser_handles_empty_source() {
     let stmts = parse_ok("");
     assert!(stmts.is_empty());
+}
+
+// -- Task 2: Literals, binary ops, unary ops, grouping --
+
+#[test]
+fn parse_integer_literal() {
+    let expr = parse_single_expr("42");
+    assert_eq!(expr, Expr::IntLiteral(42));
+}
+
+#[test]
+fn parse_float_literal() {
+    let expr = parse_single_expr("3.14");
+    assert_eq!(expr, Expr::FloatLiteral(3.14));
+}
+
+#[test]
+fn parse_string_literal() {
+    let expr = parse_single_expr("\"hello\"");
+    assert_eq!(expr, Expr::StringLiteral("hello".to_string()));
+}
+
+#[test]
+fn parse_bool_true() {
+    let expr = parse_single_expr("true");
+    assert_eq!(expr, Expr::BoolLiteral(true));
+}
+
+#[test]
+fn parse_bool_false() {
+    let expr = parse_single_expr("false");
+    assert_eq!(expr, Expr::BoolLiteral(false));
+}
+
+#[test]
+fn parse_identifier() {
+    let expr = parse_single_expr("foo");
+    assert_eq!(expr, Expr::Identifier("foo".to_string()));
+}
+
+#[test]
+fn parse_binary_add() {
+    let expr = parse_single_expr("1 + 2");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::IntLiteral(1)),
+            op: BinOp::Add,
+            right: Box::new(Expr::IntLiteral(2)),
+        }
+    );
+}
+
+#[test]
+fn parse_precedence_mul_over_add() {
+    // 1 + 2 * 3 should parse as 1 + (2 * 3)
+    let expr = parse_single_expr("1 + 2 * 3");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::IntLiteral(1)),
+            op: BinOp::Add,
+            right: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::IntLiteral(2)),
+                op: BinOp::Mul,
+                right: Box::new(Expr::IntLiteral(3)),
+            }),
+        }
+    );
+}
+
+#[test]
+fn parse_precedence_left_associative() {
+    // 1 - 2 - 3 should parse as (1 - 2) - 3
+    let expr = parse_single_expr("1 - 2 - 3");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::IntLiteral(1)),
+                op: BinOp::Sub,
+                right: Box::new(Expr::IntLiteral(2)),
+            }),
+            op: BinOp::Sub,
+            right: Box::new(Expr::IntLiteral(3)),
+        }
+    );
+}
+
+#[test]
+fn parse_grouped_expression() {
+    // (1 + 2) * 3
+    let expr = parse_single_expr("(1 + 2) * 3");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::IntLiteral(1)),
+                op: BinOp::Add,
+                right: Box::new(Expr::IntLiteral(2)),
+            }),
+            op: BinOp::Mul,
+            right: Box::new(Expr::IntLiteral(3)),
+        }
+    );
+}
+
+#[test]
+fn parse_unary_neg() {
+    let expr = parse_single_expr("-x");
+    assert_eq!(
+        expr,
+        Expr::UnaryOp {
+            op: UnOp::Neg,
+            expr: Box::new(Expr::Identifier("x".to_string())),
+        }
+    );
+}
+
+#[test]
+fn parse_unary_not() {
+    let expr = parse_single_expr("!flag");
+    assert_eq!(
+        expr,
+        Expr::UnaryOp {
+            op: UnOp::Not,
+            expr: Box::new(Expr::Identifier("flag".to_string())),
+        }
+    );
+}
+
+#[test]
+fn parse_comparison() {
+    let expr = parse_single_expr("a > b");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::Identifier("a".to_string())),
+            op: BinOp::Gt,
+            right: Box::new(Expr::Identifier("b".to_string())),
+        }
+    );
+}
+
+#[test]
+fn parse_logical_and_or() {
+    // a && b || c should parse as (a && b) || c
+    let expr = parse_single_expr("a && b || c");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier("a".to_string())),
+                op: BinOp::And,
+                right: Box::new(Expr::Identifier("b".to_string())),
+            }),
+            op: BinOp::Or,
+            right: Box::new(Expr::Identifier("c".to_string())),
+        }
+    );
+}
+
+#[test]
+fn parse_all_binary_ops() {
+    // Just verify each op parses correctly
+    for (src, op) in [
+        ("a + b", BinOp::Add),
+        ("a - b", BinOp::Sub),
+        ("a * b", BinOp::Mul),
+        ("a / b", BinOp::Div),
+        ("a % b", BinOp::Mod),
+        ("a == b", BinOp::Eq),
+        ("a != b", BinOp::NotEq),
+        ("a < b", BinOp::Lt),
+        ("a > b", BinOp::Gt),
+        ("a <= b", BinOp::LtEq),
+        ("a >= b", BinOp::GtEq),
+        ("a && b", BinOp::And),
+        ("a || b", BinOp::Or),
+    ] {
+        let expr = parse_single_expr(src);
+        match expr {
+            Expr::BinaryOp { op: parsed_op, .. } => {
+                assert_eq!(parsed_op, op, "Failed for: {}", src)
+            }
+            other => panic!("Expected BinaryOp for '{}', got {:?}", src, other),
+        }
+    }
+}
+
+#[test]
+fn parse_complex_precedence() {
+    // 1 + 2 * 3 - 4 / 2 should parse as (1 + (2 * 3)) - (4 / 2)
+    let expr = parse_single_expr("1 + 2 * 3 - 4 / 2");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::IntLiteral(1)),
+                op: BinOp::Add,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::IntLiteral(2)),
+                    op: BinOp::Mul,
+                    right: Box::new(Expr::IntLiteral(3)),
+                }),
+            }),
+            op: BinOp::Sub,
+            right: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::IntLiteral(4)),
+                op: BinOp::Div,
+                right: Box::new(Expr::IntLiteral(2)),
+            }),
+        }
+    );
+}
+
+#[test]
+fn parse_unary_in_binary() {
+    // -a + b should parse as (-a) + b
+    let expr = parse_single_expr("-a + b");
+    assert_eq!(
+        expr,
+        Expr::BinaryOp {
+            left: Box::new(Expr::UnaryOp {
+                op: UnOp::Neg,
+                expr: Box::new(Expr::Identifier("a".to_string())),
+            }),
+            op: BinOp::Add,
+            right: Box::new(Expr::Identifier("b".to_string())),
+        }
+    );
 }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -272,3 +272,154 @@ fn parse_unary_in_binary() {
         }
     );
 }
+
+// -- Task 3: Postfix expressions and function calls --
+
+#[test]
+fn parse_function_call_no_args() {
+    let expr = parse_single_expr("foo()");
+    assert_eq!(
+        expr,
+        Expr::FnCall {
+            callee: Box::new(Expr::Identifier("foo".to_string())),
+            args: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_function_call_one_arg() {
+    let expr = parse_single_expr("println(\"hello\")");
+    assert_eq!(
+        expr,
+        Expr::FnCall {
+            callee: Box::new(Expr::Identifier("println".to_string())),
+            args: vec![Expr::StringLiteral("hello".to_string())],
+        }
+    );
+}
+
+#[test]
+fn parse_function_call_multiple_args() {
+    let expr = parse_single_expr("add(1, 2)");
+    assert_eq!(
+        expr,
+        Expr::FnCall {
+            callee: Box::new(Expr::Identifier("add".to_string())),
+            args: vec![Expr::IntLiteral(1), Expr::IntLiteral(2)],
+        }
+    );
+}
+
+#[test]
+fn parse_field_access() {
+    let expr = parse_single_expr("user.name");
+    assert_eq!(
+        expr,
+        Expr::FieldAccess {
+            object: Box::new(Expr::Identifier("user".to_string())),
+            field: "name".to_string(),
+        }
+    );
+}
+
+#[test]
+fn parse_chained_field_access() {
+    // a.b.c -> FieldAccess { object: FieldAccess { object: a, field: "b" }, field: "c" }
+    let expr = parse_single_expr("a.b.c");
+    assert_eq!(
+        expr,
+        Expr::FieldAccess {
+            object: Box::new(Expr::FieldAccess {
+                object: Box::new(Expr::Identifier("a".to_string())),
+                field: "b".to_string(),
+            }),
+            field: "c".to_string(),
+        }
+    );
+}
+
+#[test]
+fn parse_safe_access() {
+    let expr = parse_single_expr("user?.name");
+    assert_eq!(
+        expr,
+        Expr::SafeAccess {
+            object: Box::new(Expr::Identifier("user".to_string())),
+            field: "name".to_string(),
+        }
+    );
+}
+
+#[test]
+fn parse_method_call() {
+    let expr = parse_single_expr("list.push(42)");
+    assert_eq!(
+        expr,
+        Expr::MethodCall {
+            object: Box::new(Expr::Identifier("list".to_string())),
+            method: "push".to_string(),
+            args: vec![Expr::IntLiteral(42)],
+        }
+    );
+}
+
+#[test]
+fn parse_index_access() {
+    let expr = parse_single_expr("items[0]");
+    assert_eq!(
+        expr,
+        Expr::Index {
+            object: Box::new(Expr::Identifier("items".to_string())),
+            index: Box::new(Expr::IntLiteral(0)),
+        }
+    );
+}
+
+#[test]
+fn parse_null_coalesce() {
+    let expr = parse_single_expr("user?.name ?? \"Unknown\"");
+    assert_eq!(
+        expr,
+        Expr::NullCoalesce {
+            left: Box::new(Expr::SafeAccess {
+                object: Box::new(Expr::Identifier("user".to_string())),
+                field: "name".to_string(),
+            }),
+            right: Box::new(Expr::StringLiteral("Unknown".to_string())),
+        }
+    );
+}
+
+#[test]
+fn parse_chained_method_calls() {
+    // a.foo().bar() -> MethodCall { object: FnCall on FieldAccess... }
+    // Actually: a.foo() is MethodCall, then .bar() is another MethodCall on the result
+    let expr = parse_single_expr("a.foo().bar()");
+    assert_eq!(
+        expr,
+        Expr::MethodCall {
+            object: Box::new(Expr::MethodCall {
+                object: Box::new(Expr::Identifier("a".to_string())),
+                method: "foo".to_string(),
+                args: vec![],
+            }),
+            method: "bar".to_string(),
+            args: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_call_on_field() {
+    // obj.field(1, 2) is a method call
+    let expr = parse_single_expr("obj.field(1, 2)");
+    assert_eq!(
+        expr,
+        Expr::MethodCall {
+            object: Box::new(Expr::Identifier("obj".to_string())),
+            method: "field".to_string(),
+            args: vec![Expr::IntLiteral(1), Expr::IntLiteral(2)],
+        }
+    );
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,0 +1,34 @@
+use sage::lexer::Lexer;
+use sage::parser::Parser;
+use sage::parser::ast::*;
+
+fn parse(source: &str) -> (Vec<Stmt>, Vec<sage::parser::ParseError>) {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize();
+    assert!(
+        lexer.errors().is_empty(),
+        "Lexer errors: {:?}",
+        lexer.errors()
+    );
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let errors = parser.errors().to_vec();
+    (stmts, errors)
+}
+
+fn parse_ok(source: &str) -> Vec<Stmt> {
+    let (stmts, errors) = parse(source);
+    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+    stmts
+}
+
+#[test]
+fn parser_constructs_without_panic() {
+    let _ = parse_ok("");
+}
+
+#[test]
+fn parser_handles_empty_source() {
+    let stmts = parse_ok("");
+    assert!(stmts.is_empty());
+}


### PR DESCRIPTION

  ## Summary                                                                                                                                                                                                                                                                                           
  - Implement a recursive descent parser with Pratt expression parsing that turns the lexer's token stream into an AST
  - Parse all Sage language constructs: expressions, statements, functions, control flow, structs/traits/impl, decorators, imports, closures, concurrency primitives                                                                                                                                   
  - Add panic mode error recovery to report multiple parse errors per pass
  - Wire parser into `sage build` CLI command

  ## Details

  **Architecture:** Consumes `Vec<Token>` from the lexer, produces `Vec<Stmt>`. Pratt parsing handles expression precedence via a binding power table. Recursive descent handles statements and declarations.

  **Pratt binding power table:**
  - `..` (range): 1/2
  - `??` (null coalesce): 4/3 (right-associative)
  - `||`: 5/6, `&&`: 7/8
  - `== != < > <= >=`: 9/10
  - `+ -`: 11/12, `* / %`: 13/14
  - unary (`-`, `!`): 15
  - postfix (`.`, `?.`, `()`, `[]`): 17

  **What parses:**
  - Literals (int, float, string, bool), identifiers, binary/unary ops, grouping
  - Function calls, method calls, field/safe access, indexing
  - Let (with mut, type annotations), return, expression statements
  - Function definitions with params and return types
  - Control flow: if/else (as expressions), for-in, while, match
  - Struct, trait, impl (inherent and trait impl) definitions
  - Decorators, imports, try/catch, test fns
  - Closures, list literals, string interpolation reassembly
  - spawn, parallel

  **Code review fixes (all 8 issues from web-audited review):**
  1. Source spans on all AST nodes (ExprKind/StmtKind wrapped in Expr/Stmt structs with Span)
  2. Recursion depth limit (128) to prevent stack overflow
  3. synchronize() infinite loop fix (force advance if stuck)
  4. Decorators on non-fn statements produce errors instead of being silently dropped
  5. `parallel` with empty closure params returns error instead of panicking
  6. `expect_identifier()` helper to reduce clone boilerplate
  7. `??` mixed with `||`/`&&` rejected without explicit parentheses
  8. `<T>` vs `<` ambiguity documented for future reference

  ## Test plan
  - [x] 89 parser tests covering all constructs, precedence, error recovery
  - [x] 7 fix-verification tests for each reviewed issue
  - [x] 3 CLI integration tests (hello.sg parses end-to-end)
  - [x] All 37 existing lexer tests still pass
  - [x] `cargo clippy` clean, `cargo fmt` clean
  
  ---
  closes #5 